### PR TITLE
feat(events): add wp extrachill events roundup command

### DIFF
--- a/inc/Commands/Events/LocationCommand.php
+++ b/inc/Commands/Events/LocationCommand.php
@@ -584,4 +584,230 @@ class LocationCommand {
 			WP_CLI::log( sprintf( 'Unresolved: %d', (int) $result['unresolved_count'] ) );
 		}
 	}
+
+	/**
+	 * Generate an event roundup carousel graphic for a date range.
+	 *
+	 * Renders Instagram-portrait (1080x1350) carousel slides listing events
+	 * grouped by day, branded with Extra Chill colors and fonts. Works for
+	 * any date range — tonight, this weekend, a custom 5-day stretch — and
+	 * can be filtered to a single location.
+	 *
+	 * Wraps the extrachill/event-roundup-build ability.
+	 *
+	 * ## OPTIONS
+	 *
+	 * [--date-start=<date>]
+	 * : Start date (Y-m-d) or "today". Defaults to today.
+	 *
+	 * [--date-end=<date>]
+	 * : End date (Y-m-d). Defaults to date-start (single-day roundup).
+	 *
+	 * [--week-start-day=<day>]
+	 * : Weekday-name shortcut (e.g. "thursday"). Resolves to the next occurrence.
+	 * Mutually exclusive with date-start.
+	 *
+	 * [--week-end-day=<day>]
+	 * : Weekday-name shortcut (e.g. "sunday"). Used with week-start-day.
+	 *
+	 * [--location=<slug-or-id>]
+	 * : Location taxonomy term slug or numeric term ID. Optional.
+	 *
+	 * [--title=<string>]
+	 * : Title shown on the first slide. Optional.
+	 *
+	 * [--output=<dir>]
+	 * : Directory to copy generated slides into. When omitted, prints the
+	 * temp file paths produced by the ability (caller must handle cleanup).
+	 *
+	 * [--format=<format>]
+	 * : Output format for the result summary.
+	 * ---
+	 * default: table
+	 * options:
+	 *   - table
+	 *   - json
+	 * ---
+	 *
+	 * ## EXAMPLES
+	 *
+	 *     # Tonight in Charleston
+	 *     wp extrachill events roundup --location=charleston --title="Tonight in Charleston" --url=events.extrachill.com
+	 *
+	 *     # This weekend (next Fri-Sun) in Charleston, save to a folder
+	 *     wp extrachill events roundup --week-start-day=friday --week-end-day=sunday \
+	 *       --location=charleston --title="This Weekend in Charleston" \
+	 *       --output=/tmp/charleston-weekend --url=events.extrachill.com
+	 *
+	 *     # Custom 5-day stretch, all locations, JSON output for piping
+	 *     wp extrachill events roundup --date-start=2026-04-25 --date-end=2026-04-30 \
+	 *       --title="End of April Lineup" --format=json --url=events.extrachill.com
+	 *
+	 *     # Single day, by date
+	 *     wp extrachill events roundup --date-start=2026-05-15 \
+	 *       --location=austin --title="Friday in Austin" --url=events.extrachill.com
+	 *
+	 * @subcommand roundup
+	 * @when after_wp_load
+	 */
+	public function roundup( $args, $assoc_args ) {
+		$ability = wp_get_ability( 'extrachill/event-roundup-build' );
+
+		if ( ! $ability ) {
+			WP_CLI::error( 'extrachill/event-roundup-build ability not available. Is extrachill-events active on this site?' );
+		}
+
+		// Map CLI flag names (kebab) → ability input keys (snake). Empty
+		// inputs are intentionally NOT passed so the ability uses its own
+		// defaults (e.g. date_start defaults to today).
+		//
+		// Date inputs are resolved at the CLI layer (natural language like
+		// "today", "tomorrow", "+3 days", or "next friday"). The ability
+		// keeps a strict Y-m-d contract for machine callers.
+		$input = array();
+
+		foreach (
+			array(
+				'date-start'     => 'date_start',
+				'date-end'       => 'date_end',
+			) as $cli_key => $ability_key
+		) {
+			if ( isset( $assoc_args[ $cli_key ] ) && '' !== $assoc_args[ $cli_key ] ) {
+				$resolved = $this->resolve_date_input( (string) $assoc_args[ $cli_key ] );
+				if ( null === $resolved ) {
+					WP_CLI::error( sprintf( 'Could not parse %s value: %s', $cli_key, $assoc_args[ $cli_key ] ) );
+				}
+				$input[ $ability_key ] = $resolved;
+			}
+		}
+
+		foreach (
+			array(
+				'week-start-day' => 'week_start_day',
+				'week-end-day'   => 'week_end_day',
+				'location'       => 'location',
+				'title'          => 'title',
+			) as $cli_key => $ability_key
+		) {
+			if ( isset( $assoc_args[ $cli_key ] ) && '' !== $assoc_args[ $cli_key ] ) {
+				$input[ $ability_key ] = (string) $assoc_args[ $cli_key ];
+			}
+		}
+
+		WP_CLI::log( 'Building event roundup...' );
+
+		$result = $ability->execute( $input );
+
+		if ( is_wp_error( $result ) ) {
+			WP_CLI::error( $result->get_error_message() );
+		}
+
+		$image_paths = (array) ( $result['image_paths'] ?? array() );
+		$output_dir  = isset( $assoc_args['output'] ) ? rtrim( (string) $assoc_args['output'], '/' ) : '';
+		$saved_paths = array();
+
+		if ( '' !== $output_dir && ! empty( $image_paths ) ) {
+			if ( ! is_dir( $output_dir ) ) {
+				if ( ! wp_mkdir_p( $output_dir ) ) {
+					WP_CLI::error( sprintf( 'Could not create output directory: %s', $output_dir ) );
+				}
+			}
+
+			foreach ( $image_paths as $i => $src ) {
+				if ( ! file_exists( $src ) ) {
+					WP_CLI::warning( sprintf( 'Slide %d source missing: %s', $i + 1, $src ) );
+					continue;
+				}
+
+				$ext  = pathinfo( $src, PATHINFO_EXTENSION ) ?: 'png';
+				$dest = sprintf( '%s/roundup-slide-%d.%s', $output_dir, $i + 1, $ext );
+
+				if ( ! copy( $src, $dest ) ) {
+					WP_CLI::warning( sprintf( 'Could not copy slide %d to %s', $i + 1, $dest ) );
+					continue;
+				}
+
+				$saved_paths[] = $dest;
+			}
+		} else {
+			$saved_paths = $image_paths;
+		}
+
+		$format = $assoc_args['format'] ?? 'table';
+
+		if ( 'json' === $format ) {
+			WP_CLI::print_value(
+				array(
+					'success'       => (bool) ( $result['success'] ?? false ),
+					'date_start'    => (string) ( $result['date_start'] ?? '' ),
+					'date_end'      => (string) ( $result['date_end'] ?? '' ),
+					'location'      => (string) ( $result['location_name'] ?? '' ),
+					'total_events'  => (int) ( $result['total_events'] ?? 0 ),
+					'slide_count'   => (int) ( $result['slide_count'] ?? 0 ),
+					'image_paths'   => $saved_paths,
+					'event_summary' => (string) ( $result['event_summary'] ?? '' ),
+					'message'       => (string) ( $result['message'] ?? '' ),
+				),
+				array( 'format' => 'json' )
+			);
+			return;
+		}
+
+		// Table format.
+		if ( empty( $result['success'] ) ) {
+			WP_CLI::warning( $result['message'] ?? 'No slides generated.' );
+			WP_CLI::log( sprintf( 'Date range: %s → %s', $result['date_start'] ?? '?', $result['date_end'] ?? '?' ) );
+			WP_CLI::log( sprintf( 'Location:   %s', $result['location_name'] ?? '?' ) );
+			return;
+		}
+
+		WP_CLI::success( sprintf( 'Generated %d slide%s', $result['slide_count'], 1 === (int) $result['slide_count'] ? '' : 's' ) );
+		WP_CLI::log( sprintf( 'Date range:   %s → %s', $result['date_start'], $result['date_end'] ) );
+		WP_CLI::log( sprintf( 'Location:     %s', $result['location_name'] ) );
+		WP_CLI::log( sprintf( 'Total events: %d', (int) $result['total_events'] ) );
+		WP_CLI::log( '' );
+		WP_CLI::log( 'Slides:' );
+		foreach ( $saved_paths as $i => $p ) {
+			WP_CLI::log( sprintf( '  %d. %s', $i + 1, $p ) );
+		}
+	}
+
+	/**
+	 * Resolve a natural-language date input into Y-m-d.
+	 *
+	 * Accepts:
+	 *   - Exact Y-m-d strings (passed through verbatim)
+	 *   - "today", "tomorrow", "yesterday"
+	 *   - PHP relative date strings: "+3 days", "next friday", "last monday"
+	 *
+	 * Resolution uses the WordPress site timezone so "today" matches what
+	 * an editor would expect, not server UTC.
+	 *
+	 * @param string $input Raw date input from the CLI flag.
+	 * @return string|null Y-m-d string on success, null on parse failure.
+	 */
+	private function resolve_date_input( string $input ): ?string {
+		$input = trim( $input );
+		if ( '' === $input ) {
+			return null;
+		}
+
+		// Exact Y-m-d → pass through (cheap path; avoids the DateTime parser
+		// reinterpreting "2026-01-02" as something weird).
+		if ( preg_match( '/^\d{4}-\d{2}-\d{2}$/', $input ) ) {
+			$check = \DateTime::createFromFormat( 'Y-m-d', $input );
+			if ( $check && $check->format( 'Y-m-d' ) === $input ) {
+				return $input;
+			}
+			return null;
+		}
+
+		try {
+			$tz   = function_exists( 'wp_timezone' ) ? wp_timezone() : new \DateTimeZone( 'UTC' );
+			$date = new \DateTime( $input, $tz );
+			return $date->format( 'Y-m-d' );
+		} catch ( \Exception $e ) {
+			return null;
+		}
+	}
 }


### PR DESCRIPTION
## Summary

Adds a new `wp extrachill events roundup` subcommand that generates Instagram-portrait carousel graphics (1080x1350, multi-slide) from any date range and location filter. Wraps the new `extrachill/event-roundup-build` ability shipped in [extrachill-events#65](https://github.com/Extra-Chill/extrachill-events/pull/65).

This unlocks **on-the-fly roundup generation** from CLI, scheduled flows, agent chat, or any automation pipeline.

## Use cases

```bash
# Tonight in Charleston
wp extrachill events roundup --location=charleston --title="Tonight in Charleston" \\
  --user=1 --url=events.extrachill.com

# This Weekend in Austin (next Fri-Sun)
wp extrachill events roundup --week-start-day=friday --week-end-day=sunday \\
  --location=austin --title="This Weekend in Austin" --output=/tmp/austin-weekend \\
  --user=1 --url=events.extrachill.com

# Custom 5-day stretch, all locations, JSON output for piping
wp extrachill events roundup --date-start=2026-04-25 --date-end=2026-04-30 \\
  --title="End of April Lineup" --format=json \\
  --user=1 --url=events.extrachill.com

# Single day (relative)
wp extrachill events roundup --date-start=tomorrow --location=charleston \\
  --title="Tomorrow in Charleston" --user=1 --url=events.extrachill.com
```

## What ships

A new `roundup` subcommand on the existing `wp extrachill events` namespace (file: `inc/Commands/Events/LocationCommand.php`).

### Flags

| Flag | Description |
|---|---|
| `--date-start=<date>` | Start date — Y-m-d, "today", "tomorrow", "+3 days", "next friday", etc. Defaults to today. |
| `--date-end=<date>` | End date. Defaults to date-start (single-day roundup). |
| `--week-start-day=<day>` | Weekday-name shortcut (e.g. "friday"). Mutually exclusive with date-start. |
| `--week-end-day=<day>` | Weekday-name shortcut (e.g. "sunday"). Used with week-start-day. |
| `--location=<slug-or-id>` | Location taxonomy term slug ("charleston", "austin") or numeric ID. Optional. |
| `--title=<string>` | Title shown on the first slide. Optional. |
| `--output=<dir>` | Directory to copy generated slides into. When omitted, prints temp file paths. |
| `--format=<format>` | `table` (default) or `json`. JSON output includes the `event_summary` text ready for AI captioning. |

### Natural-language date resolution

The CLI accepts natural-language dates and resolves them to Y-m-d at the CLI layer using PHP's `DateTime` parser plus the WordPress site timezone. The underlying ability keeps a strict Y-m-d contract so machine callers don't have to guess timezone semantics.

```
"today"        → 2026-04-25 (in site timezone)
"tomorrow"     → 2026-04-26
"+3 days"      → 2026-04-28
"next friday"  → 2026-05-01
"2026-12-25"   → 2026-12-25 (passes through, validated)
```

### Output formats

**Table** (default — human-friendly):
```
Building event roundup...
Success: Generated 2 slides
Date range:   2026-04-25 → 2026-04-25
Location:     Charleston
Total events: 18

Slides:
  1. /tmp/charleston-tonight/roundup-slide-1.png
  2. /tmp/charleston-tonight/roundup-slide-2.png
```

**JSON** (machine-readable, pipe-ready):
```json
{
  "success": true,
  "date_start": "2026-04-25",
  "date_end": "2026-04-25",
  "location": "Charleston",
  "total_events": 18,
  "slide_count": 2,
  "image_paths": ["/tmp/.../slide-1.png", "/tmp/.../slide-2.png"],
  "event_summary": "Saturday, Apr 25:\n- The Saint Cecilia @ The Royal American (9:00 PM)\n...",
  "message": "Generated 2 carousel slides."
}
```

The `event_summary` field is ready for AI captioning steps.

## Smoke tests (live data)

| Scenario | Result |
|---|---|
| `--date-start=today --location=charleston` | 18 events tonight → 2 slides ✓ |
| `--week-start-day=friday --week-end-day=sunday --location=austin` | 94 events Fri-Sun → 4 slides ✓ |
| `--date-start=tomorrow --location=charleston --format=json` | Valid JSON with full event_summary ✓ |
| `--date-start=not-a-date` | `Error: Could not parse date-start value: not-a-date` ✓ |

## Auto-generation pipeline (the bigger picture)

This command is the missing glue for fully-automated roundup posts. With this in place, a Data Machine flow scheduled daily at 4pm could be:

1. **Step 1 (CLI/handler):** `wp extrachill events roundup --date-start=today --location=charleston --title="Tonight in Charleston" --format=json`
2. **Step 2 (AI):** Generate Instagram caption from the `event_summary` text
3. **Step 3 (publish):** `roundup_publish` handler → Instagram carousel post

All three steps already exist as primitives. This PR completes step 1 as a one-shot command (the existing pipeline handler is still useful for the weekday-window scheduling case but isn't great for "tonight"-style on-demand).

## Files changed (1)

- Modified: `inc/Commands/Events/LocationCommand.php` — adds `roundup()` method (~155 LOC including help docblock and the date-input resolver helper)

## Dependencies

Requires [extrachill-events#65](https://github.com/Extra-Chill/extrachill-events/pull/65) merged + deployed before this PR is useful (the CLI calls `extrachill/event-roundup-build` which doesn't exist on `main` yet).