### PR TITLE
Add 'wp extrachill analytics attacks' command

### DIFF
--- a/inc/Commands/Analytics/AttacksCommand.php
+++ b/inc/Commands/Analytics/AttacksCommand.php
@@ -1,0 +1,168 @@
+<?php
+/**
+ * Analytics Attacks CLI Command
+ *
+ * Reports search_attack events captured by extrachill-analytics. Wraps the
+ * extrachill/get-attack-summary ability.
+ *
+ * @package ExtraChill\CLI\Commands\Analytics
+ */
+
+namespace ExtraChill\CLI\Commands\Analytics;
+
+use WP_CLI;
+use WP_CLI\Utils;
+use ExtraChill\CLI\Traits\NetworkAwareTrait;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+class AttacksCommand {
+
+	use NetworkAwareTrait;
+
+	/**
+	 * Show search_attack event summary grouped by pattern, day, IP, or URL.
+	 *
+	 * Reports scanner / injection probe activity captured by the extrachill-analytics
+	 * security classifier. Use this to spot ongoing attacks, identify the worst
+	 * offending IPs, and confirm Cloudflare WAF rules are working.
+	 *
+	 * ## OPTIONS
+	 *
+	 * [--days=<days>]
+	 * : Number of days to look back. 0 for all time.
+	 * ---
+	 * default: 28
+	 * ---
+	 *
+	 * [--group-by=<group>]
+	 * : Grouping dimension.
+	 * ---
+	 * default: pattern
+	 * options:
+	 *   - pattern
+	 *   - day
+	 *   - ip
+	 *   - url
+	 * ---
+	 *
+	 * [--limit=<limit>]
+	 * : Maximum rows to show. 0 for unlimited.
+	 * ---
+	 * default: 25
+	 * ---
+	 *
+	 * [--site=<site>]
+	 * : Filter by site. Use a blog ID, 'all' for network-wide, or omit for current site.
+	 *
+	 * [--format=<format>]
+	 * : Output format.
+	 * ---
+	 * default: table
+	 * options:
+	 *   - table
+	 *   - json
+	 *   - csv
+	 * ---
+	 *
+	 * ## EXAMPLES
+	 *
+	 *     # Top attack patterns over the last 28 days (default).
+	 *     wp extrachill analytics attacks
+	 *
+	 *     # Daily attack volume — spot attack windows.
+	 *     wp extrachill analytics attacks --group-by=day --limit=0
+	 *
+	 *     # Worst offending IPs in the last 7 days (post-Cloudflare-real-IP).
+	 *     wp extrachill analytics attacks --group-by=ip --days=7 --limit=20
+	 *
+	 *     # Which pages scanners are hitting hardest.
+	 *     wp extrachill analytics attacks --group-by=url --days=28
+	 *
+	 *     # Network-wide view, JSON output for piping into jq.
+	 *     wp extrachill analytics attacks --site=all --format=json
+	 *
+	 * @subcommand __default
+	 * @when after_wp_load
+	 */
+	public function __invoke( $args, $assoc_args ) {
+		$ability = wp_get_ability( 'extrachill/get-attack-summary' );
+
+		if ( ! $ability ) {
+			WP_CLI::error( 'extrachill/get-attack-summary ability not found. Is extrachill-analytics active and >= 0.7.0?' );
+		}
+
+		$blog_id  = $this->get_site_filter( $assoc_args );
+		$days     = (int) ( $assoc_args['days'] ?? 28 );
+		$group_by = $assoc_args['group-by'] ?? 'pattern';
+		$limit    = (int) ( $assoc_args['limit'] ?? 25 );
+		$format   = $assoc_args['format'] ?? 'table';
+
+		$input = array(
+			'days'     => $days,
+			'group_by' => $group_by,
+			'limit'    => $limit,
+		);
+
+		if ( $blog_id > 0 ) {
+			$input['blog_id'] = $blog_id;
+		}
+
+		$result = $ability->execute( $input );
+
+		if ( is_wp_error( $result ) ) {
+			WP_CLI::error( $result->get_error_message() );
+		}
+
+		if ( empty( $result['rows'] ) ) {
+			$period = $days > 0 ? "the last {$days} days" : 'all time';
+			WP_CLI::success( "No search_attack events found for {$period}." );
+			return;
+		}
+
+		// Column label depends on grouping dimension.
+		$key_label = array(
+			'pattern' => 'classification',
+			'day'     => 'date',
+			'ip'      => 'ip_address',
+			'url'     => 'source_url',
+		)[ $result['group_by'] ] ?? 'key';
+
+		// Raw integers for json/csv; thousands-separated strings for table.
+		$rows = array();
+		foreach ( $result['rows'] as $row ) {
+			$rows[] = array(
+				$key_label => $row['key'],
+				'count'    => 'table' === $format ? number_format( $row['count'] ) : (int) $row['count'],
+			);
+		}
+
+		if ( 'table' === $format ) {
+			$period_label = $days > 0 ? "Last {$days} days" : 'All time';
+			$site_label   = $this->format_site_label();
+			WP_CLI::log( sprintf(
+				'Attack Summary — %s (%s) — %s — grouped by %s',
+				$period_label,
+				$result['period'],
+				$site_label,
+				$result['group_by']
+			) );
+			WP_CLI::log( str_repeat( '─', 70 ) );
+		}
+
+		Utils\format_items( $format, $rows, array( $key_label, 'count' ) );
+
+		if ( 'table' === $format ) {
+			WP_CLI::log( '' );
+			WP_CLI::log( sprintf(
+				'Total: %s attack events across %s distinct %s%s',
+				number_format( $result['total'] ),
+				number_format( $result['distinct'] ),
+				$result['group_by'] . ( $result['distinct'] === 1 ? '' : 's' ),
+				$result['truncated'] ? sprintf( ' (showing top %d)', $limit ) : ''
+			) );
+		}
+	}
+}

--- a/inc/bootstrap.php
+++ b/inc/bootstrap.php
@@ -20,6 +20,7 @@ if ( ! defined( 'WP_CLI' ) || ! WP_CLI ) {
 // Analytics commands.
 WP_CLI::add_command( 'extrachill analytics summary', ExtraChill\CLI\Commands\Analytics\SummaryCommand::class );
 WP_CLI::add_command( 'extrachill analytics 404', ExtraChill\CLI\Commands\Analytics\FourOhFourCommand::class );
+WP_CLI::add_command( 'extrachill analytics attacks', ExtraChill\CLI\Commands\Analytics\AttacksCommand::class );
 
 // Events commands.
 WP_CLI::add_command( 'extrachill events', ExtraChill\CLI\Commands\Events\LocationCommand::class );


### PR DESCRIPTION
## Why

Pairs with [Extra-Chill/extrachill-analytics#17](https://github.com/Extra-Chill/extrachill-analytics/pull/17) which adds a security classifier and \`event_type='search_attack'\` partition. This adds the operator-facing CLI to inspect what the classifier has captured.

After the analytics PR ships, agents and operators can run:

\`\`\`
# Top attack patterns over the last 28 days
wp extrachill analytics attacks

# Daily attack volume — spot attack windows
wp extrachill analytics attacks --group-by=day --limit=0

# Worst offending IPs in the last 7 days (post-CF-real-IP)
wp extrachill analytics attacks --group-by=ip --days=7 --limit=20

# Which pages scanners hit hardest
wp extrachill analytics attacks --group-by=url --days=28

# Network-wide JSON for piping into jq
wp extrachill analytics attacks --site=all --format=json
\`\`\`

## Implementation

Thin wrapper around the new \`extrachill/get-attack-summary\` ability. Standard \`--site=\` filter via \`NetworkAwareTrait\`. Three output formats:

- \`table\` (default) — human-readable with thousands-separated counts
- \`json\` — raw integers, suitable for piping into jq
- \`csv\` — same shape as JSON, comma-delimited

## Test results from the live analytics events table

\`\`\`
$ wp extrachill analytics attacks --site=all
classification               count
time_based_sqli              11,642
scanner_path_enum            1,699
scanner_quote_probe          1,185
scanner_marker               532
scanner_encoded_gibberish    512
Total: 15,570 attack events across 5 distinct patterns

$ wp extrachill analytics attacks --site=all --group-by=day --limit=14 --days=14
date         count
2026-04-27   10,229
2026-04-19   48
2026-04-15   982
Total: 11,259 attack events across 3 distinct days

$ wp extrachill analytics attacks --site=all --group-by=url --limit=5
source_url                                              count
https://extrachill.com/                                 14,646
(empty)                                                 152
https://extrachill.com/search/1/page/page/              13
https://extrachill.com/search/1/page/page/page/         13
https://extrachill.com/search/1/page/page/page/2/       8
Total: 15,570 attack events across 302 distinct urls (showing top 5)
\`\`\`

## Dependencies

- Requires extrachill-analytics ≥ 0.7.0 (the classifier + ability PR). CLI prints a clear error if the ability isn't registered.