### PR TITLE
refactor(cli/shop): invoke abilities (#19)

### DIFF
--- a/inc/Commands/Giveaway/GiveawayCommand.php
+++ b/inc/Commands/Giveaway/GiveawayCommand.php
@@ -81,7 +81,7 @@ class GiveawayCommand {
 	public function run( $args, $assoc_args ) {
 		$ability = wp_get_ability( 'extrachill/run-giveaway' );
 		if ( ! $ability ) {
-			WP_CLI::error( 'extrachill/run-giveaway ability not available. Ensure extrachill-studio is active.' );
+			WP_CLI::error( 'extrachill/run-giveaway ability not available.' );
 		}
 
 		$require_tag = Utils\get_flag_value( $assoc_args, 'require-tag', true );


### PR DESCRIPTION
## Summary

Audit and normalize shop-domain CLI commands (`inc/Commands/Giveaway/`) for canonical ability pattern compliance per #19.

- **Normalized** `run()` error message to match canonical pattern (dropped plugin-specific `Ensure extrachill-studio is active.` hint)
- **Confirmed** `resolve()` already uses canonical `wp_get_ability()` / `execute()` pattern — no changes needed
- **Left as-is** `schedule()` — CLI-only orchestration via `DataMachine\Engine\Tasks\TaskScheduler`, no matching ability

## Audit results

| Subcommand | Method | Ability | Status |
|---|---|---|---|
| `wp extrachill giveaway run` | `run()` | `extrachill/run-giveaway` | ✅ Already canonical (error msg normalized) |
| `wp extrachill giveaway resolve` | `resolve()` | `extrachill/resolve-instagram-media` | ✅ Already canonical |
| `wp extrachill giveaway schedule` | `schedule()` | _(none — CLI-only)_ | ⏭️ Skipped per #19 guidelines |

## Gaps: shop abilities without CLI commands

The 14 abilities registered by `extrachill-shop` (merged in shop#5) have **no CLI command counterparts** yet:

| Ability | CLI command |
|---|---|
| `extrachill/shop-list-orders` | ❌ none |
| `extrachill/shop-refund-order` | ❌ none |
| `extrachill/shop-update-order-status` | ❌ none |
| `extrachill/shop-list-products` | ❌ none |
| `extrachill/shop-get-product` | ❌ none |
| `extrachill/shop-upload-product-image` | ❌ none |
| `extrachill/shop-get-shipping-address` | ❌ none |
| `extrachill/shop-update-shipping-address` | ❌ none |
| `extrachill/shop-list-shipping-labels` | ❌ none |
| `extrachill/shop-get-shipping-label` | ❌ none |
| `extrachill/shop-stripe-dashboard-link` | ❌ none |
| `extrachill/shop-stripe-onboarding-link` | ❌ none |
| `extrachill/shop-stripe-status` | ❌ none |
| `extrachill/shop-taxonomy-counts` | ❌ none |

These abilities exist server-side but have no CLI surface. Adding CLI commands for them is additive new work, not a refactor — tracked separately if needed.

## Checklist

- [x] Every shop-domain command method with a matching ability uses the canonical pattern
- [x] Argument resolution / output formatting / error rendering unchanged
- [x] CLI-only commands without ability counterparts unchanged
- [x] PHP lint clean (`find inc -name '*.php' -exec php -l {} \;`)
- [x] PR opened, NOT merged