### PR TITLE
refactor(cli/users): invoke abilities (#19)

### DIFF
--- a/inc/Commands/Users/ProfileCommand.php
+++ b/inc/Commands/Users/ProfileCommand.php
@@ -135,6 +135,65 @@ class ProfileCommand {
 		WP_CLI::log( wp_json_encode( $result, JSON_PRETTY_PRINT ) );
 	}
 
+	/**
+	 * Update user profile links.
+	 *
+	 * Replaces all existing profile links with the provided set.
+	 * Each link requires a type key and URL. Pass links as a JSON array.
+	 *
+	 * Valid type keys: website, facebook, instagram, twitter, youtube,
+	 * tiktok, spotify, soundcloud, bandcamp, github, other.
+	 *
+	 * ## OPTIONS
+	 *
+	 * <user>
+	 * : User ID, login, or email.
+	 *
+	 * <links-json>
+	 * : JSON array of link objects. Each object: {"type_key":"...", "url":"...", "custom_label":"..."}.
+	 *
+	 * ## EXAMPLES
+	 *
+	 *     wp extrachill users profile update-links chubes '[{"type_key":"website","url":"https://extrachill.com"},{"type_key":"instagram","url":"https://instagram.com/extrachill"}]'
+	 *     wp extrachill users profile update-links 1 '[]'
+	 *
+	 * @subcommand update-links
+	 * @when after_wp_load
+	 */
+	public function update_links( $args, $assoc_args ) {
+		$user = $this->resolve_user( $args[0] ?? '' );
+		if ( ! $user ) {
+			WP_CLI::error( 'User not found.' );
+		}
+
+		$links_raw = $args[1] ?? '';
+		$links     = json_decode( $links_raw, true );
+
+		if ( ! is_array( $links ) ) {
+			WP_CLI::error( 'Links must be a valid JSON array.' );
+		}
+
+		$ability = wp_get_ability( 'extrachill/update-user-links' );
+		if ( ! $ability ) {
+			WP_CLI::error( 'extrachill/update-user-links ability not available.' );
+		}
+
+		$result = $ability->execute(
+			array(
+				'user_id' => (int) $user->ID,
+				'links'   => $links,
+			)
+		);
+
+		if ( is_wp_error( $result ) ) {
+			WP_CLI::error( $result->get_error_message() );
+		}
+
+		$count = isset( $result['links'] ) ? count( $result['links'] ) : 0;
+		WP_CLI::success( sprintf( 'Updated %d link(s) for user %d (%s).', $count, (int) $user->ID, $user->user_login ) );
+		WP_CLI::log( wp_json_encode( $result, JSON_PRETTY_PRINT ) );
+	}
+
 	private function resolve_user( $identifier ) {
 		if ( is_numeric( $identifier ) ) {
 			return get_user_by( 'id', (int) $identifier );

--- a/inc/Commands/Users/SettingsCommand.php
+++ b/inc/Commands/Users/SettingsCommand.php
@@ -133,6 +133,111 @@ class SettingsCommand {
 		WP_CLI::log( wp_json_encode( $result, JSON_PRETTY_PRINT ) );
 	}
 
+	/**
+	 * Initiate an email change for a user.
+	 *
+	 * Sends a verification email to the new address. The email is not
+	 * changed until the user clicks the confirmation link.
+	 *
+	 * ## OPTIONS
+	 *
+	 * <user>
+	 * : User ID, login, or email.
+	 *
+	 * <new-email>
+	 * : New email address.
+	 *
+	 * ## EXAMPLES
+	 *
+	 *     wp extrachill users settings change-email chubes chris@example.com
+	 *     wp extrachill users settings change-email 1 newemail@extrachill.com
+	 *
+	 * @subcommand change-email
+	 * @when after_wp_load
+	 */
+	public function change_email( $args, $assoc_args ) {
+		$user = $this->resolve_user( $args[0] ?? '' );
+		if ( ! $user ) {
+			WP_CLI::error( 'User not found.' );
+		}
+
+		$new_email = $args[1] ?? '';
+		if ( empty( $new_email ) ) {
+			WP_CLI::error( 'New email address is required.' );
+		}
+
+		$ability = wp_get_ability( 'extrachill/change-user-email' );
+		if ( ! $ability ) {
+			WP_CLI::error( 'extrachill/change-user-email ability not available.' );
+		}
+
+		$result = $ability->execute(
+			array(
+				'user_id'   => (int) $user->ID,
+				'new_email' => (string) $new_email,
+			)
+		);
+
+		if ( is_wp_error( $result ) ) {
+			WP_CLI::error( $result->get_error_message() );
+		}
+
+		WP_CLI::success( $result['message'] ?? sprintf( 'Verification email sent for user %d (%s).', (int) $user->ID, $user->user_login ) );
+	}
+
+	/**
+	 * Change a user's password.
+	 *
+	 * Requires the current password for verification.
+	 *
+	 * ## OPTIONS
+	 *
+	 * <user>
+	 * : User ID, login, or email.
+	 *
+	 * --current-password=<current-password>
+	 * : Current password.
+	 *
+	 * --new-password=<new-password>
+	 * : New password.
+	 *
+	 * --confirm-password=<confirm-password>
+	 * : Confirm new password.
+	 *
+	 * ## EXAMPLES
+	 *
+	 *     wp extrachill users settings change-password chubes --current-password=old123 --new-password=new456 --confirm-password=new456
+	 *
+	 * @subcommand change-password
+	 * @when after_wp_load
+	 */
+	public function change_password( $args, $assoc_args ) {
+		$user = $this->resolve_user( $args[0] ?? '' );
+		if ( ! $user ) {
+			WP_CLI::error( 'User not found.' );
+		}
+
+		$ability = wp_get_ability( 'extrachill/change-user-password' );
+		if ( ! $ability ) {
+			WP_CLI::error( 'extrachill/change-user-password ability not available.' );
+		}
+
+		$result = $ability->execute(
+			array(
+				'user_id'          => (int) $user->ID,
+				'current_password' => (string) ( $assoc_args['current-password'] ?? '' ),
+				'new_password'     => (string) ( $assoc_args['new-password'] ?? '' ),
+				'confirm_password' => (string) ( $assoc_args['confirm-password'] ?? '' ),
+			)
+		);
+
+		if ( is_wp_error( $result ) ) {
+			WP_CLI::error( $result->get_error_message() );
+		}
+
+		WP_CLI::success( $result['message'] ?? sprintf( 'Password changed for user %d (%s).', (int) $user->ID, $user->user_login ) );
+	}
+
 	private function resolve_user( $identifier ) {
 		if ( is_numeric( $identifier ) ) {
 			return get_user_by( 'id', (int) $identifier );


### PR DESCRIPTION
## Summary

Adds CLI methods for users-domain abilities that were registered in extrachill-users but lacked CLI coverage. All new methods follow the canonical `wp_get_ability()` → `execute()` pattern per [SettingsCommand reference](https://github.com/Extra-Chill/extrachill-cli/blob/main/inc/Commands/Users/SettingsCommand.php).

Closes the **users** batch of #19.

## Changes

### `SettingsCommand.php`
- **`change-email`** — wraps `extrachill/change-user-email`. Resolves user, invokes ability, reports verification email sent.
- **`change-password`** — wraps `extrachill/change-user-password`. Requires `--current-password`, `--new-password`, `--confirm-password`.

### `ProfileCommand.php`
- **`update-links`** — wraps `extrachill/update-user-links`. Accepts a JSON array of `{type_key, url, custom_label}` link objects. Replaces all existing links.

## What was already canonical (unchanged)

All 10 existing command methods in the users domain already used `wp_get_ability()` → `execute()`:

| Command | Methods | Status |
|---|---|---|
| `SettingsCommand` | `get()`, `update()` | ✅ Already canonical |
| `ProfileCommand` | `get()`, `update()` | ✅ Already canonical |
| `BanCommand` | `ban()`, `unban()`, `ban_status()` | ✅ Already canonical |
| `ArtistAccessCommand` | `list_requests()`, `approve()`, `reject()` | ✅ Already canonical |

## Users-domain abilities without CLI coverage (intentionally skipped)

These abilities exist but have no matching CLI command. They are either CLI-only utilities, admin-internal operations, or better suited for future PRs:

- `extrachill/create-user` — admin provisioning; `wp user create` covers the basic case
- `extrachill/validate-username` — read-only validation helper, not a standalone CLI task
- `extrachill/send-welcome-email` — triggered automatically during registration
- `extrachill/complete-onboarding`, `extrachill/get-onboarding-status` — onboarding flow; interactive/app-facing
- `extrachill/grant-lifetime-membership`, `extrachill/revoke-lifetime-membership` — membership management (future batch)
- `extrachill/manage-team-member`, `extrachill/sync-team-members` — team management (future batch)
- `extrachill/request-artist-access` — user-facing action, not an admin CLI operation

## Verification

- `php -l` passes on all 19 PHP files in `inc/` — zero syntax errors
- No CHANGELOG or version string changes