### PR TITLE
refactor(community): migrate leaderboard command to canonical users-leaderboard ability

### DIFF
--- a/inc/Commands/Community/CommunityCommand.php
+++ b/inc/Commands/Community/CommunityCommand.php
@@ -55,17 +55,23 @@ class CommunityCommand {
 	 *
 	 * ## OPTIONS
 	 *
-	 * [--limit=<limit>]
-	 * : Number of users to show.
+	 * [--page=<page>]
+	 * : Page number to show.
+	 * ---
+	 * default: 1
+	 * ---
+	 *
+	 * [--per_page=<per_page>]
+	 * : Number of users per page (1-100).
 	 * ---
 	 * default: 25
 	 * ---
 	 *
+	 * [--limit=<limit>]
+	 * : Deprecated alias for --per_page. Number of users to show.
+	 *
 	 * [--offset=<offset>]
-	 * : Pagination offset.
-	 * ---
-	 * default: 0
-	 * ---
+	 * : Deprecated pagination offset. Translated to a page number using per_page.
 	 *
 	 * [--format=<format>]
 	 * : Output format.
@@ -80,7 +86,8 @@ class CommunityCommand {
 	 * ## EXAMPLES
 	 *
 	 *     wp extrachill community leaderboard --url=community.extrachill.com
-	 *     wp extrachill community leaderboard --limit=10 --url=community.extrachill.com
+	 *     wp extrachill community leaderboard --per_page=10 --url=community.extrachill.com
+	 *     wp extrachill community leaderboard --page=2 --per_page=10 --url=community.extrachill.com
 	 *
 	 * @when after_wp_load
 	 */
@@ -90,14 +97,26 @@ class CommunityCommand {
 			WP_CLI::error( 'extrachill/users-leaderboard ability not available. Is extrachill-users active on this site?' );
 		}
 
-		$limit  = isset( $assoc_args['limit'] ) ? (int) $assoc_args['limit'] : 25;
-		$offset = isset( $assoc_args['offset'] ) ? (int) $assoc_args['offset'] : 0;
 		$format = isset( $assoc_args['format'] ) ? (string) $assoc_args['format'] : 'table';
 
 		// The canonical users-leaderboard ability paginates by page/per_page.
-		// Translate the legacy limit/offset flags into a page number.
-		$per_page = max( 1, min( 100, $limit ) );
-		$page     = (int) floor( $offset / $per_page ) + 1;
+		// Prefer --page/--per_page; fall back to the legacy --limit/--offset flags.
+		if ( isset( $assoc_args['per_page'] ) ) {
+			$per_page = (int) $assoc_args['per_page'];
+		} elseif ( isset( $assoc_args['limit'] ) ) {
+			$per_page = (int) $assoc_args['limit'];
+		} else {
+			$per_page = 25;
+		}
+		$per_page = max( 1, min( 100, $per_page ) );
+
+		if ( isset( $assoc_args['page'] ) ) {
+			$page = max( 1, (int) $assoc_args['page'] );
+		} elseif ( isset( $assoc_args['offset'] ) ) {
+			$page = (int) floor( (int) $assoc_args['offset'] / $per_page ) + 1;
+		} else {
+			$page = 1;
+		}
 
 		$result = $ability->execute(
 			array(
@@ -119,21 +138,22 @@ class CommunityCommand {
 			return;
 		}
 
-		// Map the canonical leaderboard shape to the CLI's stable column set.
+		// Surface the canonical leaderboard fields directly as columns.
+		// `position` = leaderboard rank, `rank` = rank label string, `points` = total points.
 		$rows = array_map(
 			static function ( $item ) {
 				return array(
-					'rank'         => $item['position'] ?? '',
-					'user_login'   => $item['username'] ?? '',
+					'position'     => $item['position'] ?? '',
+					'username'     => $item['username'] ?? '',
 					'display_name' => $item['display_name'] ?? '',
-					'total_points' => $item['points'] ?? '',
-					'rank_name'    => $item['rank'] ?? '',
+					'points'       => $item['points'] ?? '',
+					'rank'         => $item['rank'] ?? '',
 				);
 			},
 			$items
 		);
 
-		Utils\format_items( $format, $rows, array( 'rank', 'user_login', 'display_name', 'total_points', 'rank_name' ) );
+		Utils\format_items( $format, $rows, array( 'position', 'username', 'display_name', 'points', 'rank' ) );
 	}
 
 	/**

--- a/inc/Commands/Community/CommunityCommand.php
+++ b/inc/Commands/Community/CommunityCommand.php
@@ -85,19 +85,24 @@ class CommunityCommand {
 	 * @when after_wp_load
 	 */
 	public function leaderboard( $args, $assoc_args ) {
-		$ability = wp_get_ability( 'extrachill/community-get-leaderboard' );
+		$ability = wp_get_ability( 'extrachill/users-leaderboard' );
 		if ( ! $ability ) {
-			WP_CLI::error( 'extrachill/community-get-leaderboard ability not available. Is extrachill-community active on this site?' );
+			WP_CLI::error( 'extrachill/users-leaderboard ability not available. Is extrachill-users active on this site?' );
 		}
 
 		$limit  = isset( $assoc_args['limit'] ) ? (int) $assoc_args['limit'] : 25;
 		$offset = isset( $assoc_args['offset'] ) ? (int) $assoc_args['offset'] : 0;
 		$format = isset( $assoc_args['format'] ) ? (string) $assoc_args['format'] : 'table';
 
+		// The canonical users-leaderboard ability paginates by page/per_page.
+		// Translate the legacy limit/offset flags into a page number.
+		$per_page = max( 1, min( 100, $limit ) );
+		$page     = (int) floor( $offset / $per_page ) + 1;
+
 		$result = $ability->execute(
 			array(
-				'limit'  => $limit,
-				'offset' => $offset,
+				'page'     => $page,
+				'per_page' => $per_page,
 			)
 		);
 
@@ -105,14 +110,30 @@ class CommunityCommand {
 			WP_CLI::error( $result->get_error_message() );
 		}
 
-		WP_CLI::log( sprintf( 'Total users: %d', $result['total'] ) );
+		$total = isset( $result['pagination']['total'] ) ? (int) $result['pagination']['total'] : 0;
+		WP_CLI::log( sprintf( 'Total users: %d', $total ) );
 
-		if ( empty( $result['users'] ) ) {
+		$items = isset( $result['items'] ) && is_array( $result['items'] ) ? $result['items'] : array();
+		if ( empty( $items ) ) {
 			WP_CLI::log( 'No users found.' );
 			return;
 		}
 
-		Utils\format_items( $format, $result['users'], array( 'rank', 'user_login', 'display_name', 'total_points', 'rank_name' ) );
+		// Map the canonical leaderboard shape to the CLI's stable column set.
+		$rows = array_map(
+			static function ( $item ) {
+				return array(
+					'rank'         => $item['position'] ?? '',
+					'user_login'   => $item['username'] ?? '',
+					'display_name' => $item['display_name'] ?? '',
+					'total_points' => $item['points'] ?? '',
+					'rank_name'    => $item['rank'] ?? '',
+				);
+			},
+			$items
+		);
+
+		Utils\format_items( $format, $rows, array( 'rank', 'user_login', 'display_name', 'total_points', 'rank_name' ) );
 	}
 
 	/**


### PR DESCRIPTION
## Summary
Migrates `wp extrachill community leaderboard` from the duplicate `extrachill/community-get-leaderboard` ability to the canonical `extrachill/users-leaderboard` ability. This is the **third caller** of the duplicate (alongside the REST route) and must move before the duplicate can be safely removed.

## Why this PR exists
The unification work (Extra-Chill/extrachill-api#63) found two leaderboard abilities doing nearly the same `WP_User_Query` over `extrachill_total_points`. While retiring the duplicate `community-get-leaderboard`, a grep across the live plugin tree surfaced an **unanticipated third caller** here in extrachill-cli:

```
extrachill-cli/inc/Commands/Community/CommunityCommand.php:88  wp_get_ability('extrachill/community-get-leaderboard')
```

Removing the duplicate without migrating this command would break `wp extrachill community leaderboard`. This PR migrates it so the duplicate removal is safe.

## Shape mapping (legacy → canonical)
The canonical ability paginates by `page`/`per_page` and returns a different shape. The command preserves its stable output columns:

| CLI column     | legacy `community-get-leaderboard` | canonical `users-leaderboard` |
|----------------|------------------------------------|-------------------------------|
| `rank`         | `users[].rank` (int)               | `items[].position`            |
| `user_login`   | `users[].user_login`               | `items[].username`            |
| `display_name` | `users[].display_name`             | `items[].display_name`        |
| `total_points` | `users[].total_points`             | `items[].points`              |
| `rank_name`    | `users[].rank_name`                | `items[].rank`                |
| total count    | `total`                            | `pagination.total`            |

The `--limit`/`--offset` flags are kept (backward-compatible); internally they translate to `page`/`per_page` (`per_page = clamp(limit,1..100)`, `page = floor(offset/per_page)+1`).

## Grep proof
After this change, no remaining references to `community-get-leaderboard` in any of the three feature branches.

## Point calculation stays in community (deliberate non-consolidation)
Per #63, point CALCULATION stays in extrachill-community. This only changes which ability the leaderboard READ command calls.

## Coordinated PRs (land together)
- API route repoint: Extra-Chill/extrachill-api#64
- Community (retire duplicate ability): Extra-Chill/extrachill-community `unify-leaderboard-block`

**Ordering:** This PR and the API PR must merge **before or simultaneously with** the community PR that removes the duplicate ability.