### PR TITLE
style: clear phpcs lint debt (release preflight)

### DIFF
--- a/inc/Commands/Analytics/AttacksCommand.php
+++ b/inc/Commands/Analytics/AttacksCommand.php
@@ -160,7 +160,7 @@ class AttacksCommand {
 				'Total: %s attack events across %s distinct %s%s',
 				number_format( $result['total'] ),
 				number_format( $result['distinct'] ),
-				$result['group_by'] . ( $result['distinct'] === 1 ? '' : 's' ),
+				$result['group_by'] . ( 1 === $result['distinct'] ? '' : 's' ),
 				$result['truncated'] ? sprintf( ' (showing top %d)', $limit ) : ''
 			) );
 		}

--- a/inc/Commands/Artists/ArtistCommand.php
+++ b/inc/Commands/Artists/ArtistCommand.php
@@ -60,7 +60,7 @@ class ArtistCommand {
 
 		$format = $assoc_args['format'] ?? 'table';
 
-		if ( $format === 'json' ) {
+		if ( 'json' === $format ) {
 			WP_CLI::log( wp_json_encode( $result, JSON_PRETTY_PRINT ) );
 		} else {
 			$display = array();
@@ -140,7 +140,7 @@ class ArtistCommand {
 		WP_CLI::success( sprintf( 'Artist created: %s (ID: %d)', $result['name'], $result['id'] ) );
 
 		$format = $assoc_args['format'] ?? 'table';
-		if ( $format === 'json' ) {
+		if ( 'json' === $format ) {
 			WP_CLI::log( wp_json_encode( $result, JSON_PRETTY_PRINT ) );
 		}
 	}
@@ -224,7 +224,7 @@ class ArtistCommand {
 		WP_CLI::success( sprintf( 'Artist updated: %s (ID: %d)', $result['name'], $result['id'] ) );
 
 		$format = $assoc_args['format'] ?? 'table';
-		if ( $format === 'json' ) {
+		if ( 'json' === $format ) {
 			WP_CLI::log( wp_json_encode( $result, JSON_PRETTY_PRINT ) );
 		}
 	}
@@ -270,9 +270,9 @@ class ArtistCommand {
 
 		$format = $assoc_args['format'] ?? 'json';
 
-		if ( $format === 'json' ) {
+		if ( 'json' === $format ) {
 			WP_CLI::log( wp_json_encode( $result, JSON_PRETTY_PRINT ) );
-		} elseif ( $format === 'yaml' ) {
+		} elseif ( 'yaml' === $format ) {
 			WP_CLI::log( \Spyc::YAMLDump( $result, false, false, true ) );
 		}
 	}
@@ -332,7 +332,7 @@ class ArtistCommand {
 		WP_CLI::success( sprintf( 'Saved %d social link(s) for artist %d.', $count, $artist_id ) );
 
 		$format = $assoc_args['format'] ?? 'json';
-		if ( $format === 'json' ) {
+		if ( 'json' === $format ) {
 			WP_CLI::log( wp_json_encode( $result, JSON_PRETTY_PRINT ) );
 		}
 	}
@@ -439,11 +439,13 @@ class ArtistCommand {
 		$links = $current['links'] ?? array();
 
 		// Ensure the target section exists.
-		while ( count( $links ) <= $section ) {
-			$links[] = array(
+		$link_count = count( $links );
+		while ( $link_count <= $section ) {
+			$links[]    = array(
 				'section_title' => $assoc_args['section-title'] ?? '',
 				'links'         => array(),
 			);
+			$link_count = count( $links );
 		}
 
 		// Check for duplicate URL in the target section.
@@ -631,11 +633,13 @@ class ArtistCommand {
 		$to_section = isset( $assoc_args['to-section'] ) ? absint( $assoc_args['to-section'] ) : $from_si;
 
 		// Ensure target section exists.
-		while ( count( $links ) <= $to_section ) {
-			$links[] = array(
+		$target_count = count( $links );
+		while ( $target_count <= $to_section ) {
+			$links[]      = array(
 				'section_title' => '',
 				'links'         => array(),
 			);
+			$target_count = count( $links );
 		}
 
 		$target_links = &$links[ $to_section ]['links'];
@@ -739,7 +743,10 @@ class ArtistCommand {
 
 			$display = array();
 			foreach ( $current['css_vars'] ?? array() as $key => $value ) {
-				$display[] = array( 'Variable' => $key, 'Value' => $value );
+				$display[] = array(
+					'Variable' => $key,
+					'Value'    => $value,
+				);
 			}
 			Utils\format_items( 'table', $display, array( 'Variable', 'Value' ) );
 			return;
@@ -770,7 +777,7 @@ class ArtistCommand {
 			$raw_vars = is_array( $assoc_args['css-var'] ) ? $assoc_args['css-var'] : array( $assoc_args['css-var'] );
 			foreach ( $raw_vars as $pair ) {
 				$eq_pos = strpos( $pair, '=' );
-				if ( $eq_pos !== false ) {
+				if ( false !== $eq_pos ) {
 					$key            = substr( $pair, 0, $eq_pos );
 					$value          = substr( $pair, $eq_pos + 1 );
 					$css_vars[ $key ] = $value;
@@ -887,5 +894,4 @@ class ArtistCommand {
 		}
 		WP_CLI::success( sprintf( 'Updated %d setting(s) for artist %d.', count( $settings ), $artist_id ) );
 	}
-
 }

--- a/inc/Commands/Cache/WarmCommand.php
+++ b/inc/Commands/Cache/WarmCommand.php
@@ -98,7 +98,7 @@ class WarmCommand {
 			if ( $events_blog_id ) {
 				switch_to_blog( $events_blog_id );
 				$cached = get_transient( 'ec_upcoming_counts_location' );
-				WP_CLI::log( $cached !== false
+				WP_CLI::log( false !== $cached
 					? sprintf( '  blog/location-events: WARM (%d terms)', count( $cached ) )
 					: '  blog/location-events: COLD' );
 				restore_current_blog();
@@ -108,7 +108,7 @@ class WarmCommand {
 			if ( $wire_blog_id ) {
 				switch_to_blog( $wire_blog_id );
 				$cached = get_transient( 'ec_wire_counts_festival' );
-				WP_CLI::log( $cached !== false
+				WP_CLI::log( false !== $cached
 					? sprintf( '  blog/wire-festivals: WARM (%d terms)', count( $cached ) )
 					: '  blog/wire-festivals: COLD' );
 				restore_current_blog();

--- a/inc/Commands/Community/CommunityCommand.php
+++ b/inc/Commands/Community/CommunityCommand.php
@@ -40,11 +40,26 @@ class CommunityCommand {
 		}
 
 		$items = array(
-			array( 'Metric' => 'Forums', 'Value' => $result['forums'] ),
-			array( 'Metric' => 'Topics', 'Value' => $result['topics'] ),
-			array( 'Metric' => 'Replies', 'Value' => $result['replies'] ),
-			array( 'Metric' => 'Active Users', 'Value' => $result['active_users'] ),
-			array( 'Metric' => 'Total Upvotes', 'Value' => $result['total_upvotes'] ),
+			array(
+				'Metric' => 'Forums',
+				'Value'  => $result['forums'],
+			),
+			array(
+				'Metric' => 'Topics',
+				'Value'  => $result['topics'],
+			),
+			array(
+				'Metric' => 'Replies',
+				'Value'  => $result['replies'],
+			),
+			array(
+				'Metric' => 'Active Users',
+				'Value'  => $result['active_users'],
+			),
+			array(
+				'Metric' => 'Total Upvotes',
+				'Value'  => $result['total_upvotes'],
+			),
 		);
 
 		Utils\format_items( 'table', $items, array( 'Metric', 'Value' ) );
@@ -208,10 +223,22 @@ class CommunityCommand {
 		}
 
 		$items = array(
-			array( 'Field' => 'User', 'Value' => sprintf( '%s (%d)', $result['user_login'], $result['user_id'] ) ),
-			array( 'Field' => 'Display Name', 'Value' => $result['display_name'] ),
-			array( 'Field' => 'Points', 'Value' => $result['total_points'] ),
-			array( 'Field' => 'Rank', 'Value' => $result['rank'] ),
+			array(
+				'Field' => 'User',
+				'Value' => sprintf( '%s (%d)', $result['user_login'], $result['user_id'] ),
+			),
+			array(
+				'Field' => 'Display Name',
+				'Value' => $result['display_name'],
+			),
+			array(
+				'Field' => 'Points',
+				'Value' => $result['total_points'],
+			),
+			array(
+				'Field' => 'Rank',
+				'Value' => $result['rank'],
+			),
 		);
 
 		Utils\format_items( 'table', $items, array( 'Field', 'Value' ) );
@@ -685,14 +712,38 @@ class CommunityCommand {
 
 		$t = $result['topic'];
 		$items = array(
-			array( 'Field' => 'Topic ID', 'Value' => $t['topic_id'] ),
-			array( 'Field' => 'Title', 'Value' => $t['title'] ),
-			array( 'Field' => 'Forum ID', 'Value' => $t['forum_id'] ),
-			array( 'Field' => 'Author', 'Value' => sprintf( '%s (%d)', $t['author_name'], $t['author_id'] ) ),
-			array( 'Field' => 'Replies', 'Value' => $t['reply_count'] ),
-			array( 'Field' => 'Voices', 'Value' => $t['voice_count'] ),
-			array( 'Field' => 'Date', 'Value' => $t['date'] ),
-			array( 'Field' => 'URL', 'Value' => $t['url'] ),
+			array(
+				'Field' => 'Topic ID',
+				'Value' => $t['topic_id'],
+			),
+			array(
+				'Field' => 'Title',
+				'Value' => $t['title'],
+			),
+			array(
+				'Field' => 'Forum ID',
+				'Value' => $t['forum_id'],
+			),
+			array(
+				'Field' => 'Author',
+				'Value' => sprintf( '%s (%d)', $t['author_name'], $t['author_id'] ),
+			),
+			array(
+				'Field' => 'Replies',
+				'Value' => $t['reply_count'],
+			),
+			array(
+				'Field' => 'Voices',
+				'Value' => $t['voice_count'],
+			),
+			array(
+				'Field' => 'Date',
+				'Value' => $t['date'],
+			),
+			array(
+				'Field' => 'URL',
+				'Value' => $t['url'],
+			),
 		);
 
 		Utils\format_items( 'table', $items, array( 'Field', 'Value' ) );

--- a/inc/Commands/Events/ConcertTrackingCommand.php
+++ b/inc/Commands/Events/ConcertTrackingCommand.php
@@ -184,7 +184,10 @@ class ConcertTrackingCommand {
 			$rows = array();
 			foreach ( $data as $key => $value ) {
 				$display = is_bool( $value ) ? ( $value ? 'yes' : 'no' ) : $value;
-				$rows[]  = array( 'Field' => $key, 'Value' => $display );
+				$rows[]  = array(
+					'Field' => $key,
+					'Value' => $display,
+				);
 			}
 			WP_CLI\Utils\format_items( 'table', $rows, array( 'Field', 'Value' ) );
 		}
@@ -288,7 +291,7 @@ class ConcertTrackingCommand {
 			$rows[]  = array(
 				'event_id' => $show['event_id'],
 				'date'     => $show['event_date'] ?? '',
-				'artist'   => mb_substr( $artists ?: $show['title'], 0, 40 ),
+				'artist'   => mb_substr( $artists ? $artists : $show['title'], 0, 40 ),
 				'venue'    => $show['venue']['name'] ?? '',
 				'city'     => $show['city']['name'] ?? '',
 				'timing'   => $show['timing'] ?? '',
@@ -357,17 +360,35 @@ class ConcertTrackingCommand {
 		WP_CLI::log( str_repeat( '─', strlen( $label ) ) );
 
 		$rows = array(
-			array( 'Metric' => 'Total Shows', 'Value' => $stats['total_shows'] ),
-			array( 'Metric' => 'Unique Venues', 'Value' => $stats['unique_venues'] ),
-			array( 'Metric' => 'Unique Artists', 'Value' => $stats['unique_artists'] ),
-			array( 'Metric' => 'Unique Cities', 'Value' => $stats['unique_cities'] ),
+			array(
+				'Metric' => 'Total Shows',
+				'Value'  => $stats['total_shows'],
+			),
+			array(
+				'Metric' => 'Unique Venues',
+				'Value'  => $stats['unique_venues'],
+			),
+			array(
+				'Metric' => 'Unique Artists',
+				'Value'  => $stats['unique_artists'],
+			),
+			array(
+				'Metric' => 'Unique Cities',
+				'Value'  => $stats['unique_cities'],
+			),
 		);
 
 		if ( $stats['first_show'] ) {
-			$rows[] = array( 'Metric' => 'First Show', 'Value' => $stats['first_show']['date'] . ' — ' . $stats['first_show']['title'] );
+			$rows[] = array(
+				'Metric' => 'First Show',
+				'Value'  => $stats['first_show']['date'] . ' — ' . $stats['first_show']['title'],
+			);
 		}
 		if ( $stats['latest_show'] ) {
-			$rows[] = array( 'Metric' => 'Latest Show', 'Value' => $stats['latest_show']['date'] . ' — ' . $stats['latest_show']['title'] );
+			$rows[] = array(
+				'Metric' => 'Latest Show',
+				'Value'  => $stats['latest_show']['date'] . ' — ' . $stats['latest_show']['title'],
+			);
 		}
 
 		WP_CLI\Utils\format_items( 'table', $rows, array( 'Metric', 'Value' ) );
@@ -392,7 +413,10 @@ class ConcertTrackingCommand {
 			WP_CLI::log( 'Shows by Year:' );
 			$year_rows = array();
 			foreach ( $stats['shows_by_year'] as $yr => $count ) {
-				$year_rows[] = array( 'Year' => $yr, 'Shows' => $count );
+				$year_rows[] = array(
+					'Year'  => $yr,
+					'Shows' => $count,
+				);
 			}
 			WP_CLI\Utils\format_items( 'table', $year_rows, array( 'Year', 'Shows' ) );
 		}
@@ -477,9 +501,18 @@ class ConcertTrackingCommand {
 		$count_label = $result['count_label'] ?? (string) ( $result['count'] ?? 0 );
 
 		$rows = array(
-			array( 'Field' => 'Event', 'Value' => $data['title'] ),
-			array( 'Field' => 'Timing', 'Value' => $data['timing'] . ' (' . $data['label'] . ')' ),
-			array( 'Field' => 'Attendance', 'Value' => $count_label ),
+			array(
+				'Field' => 'Event',
+				'Value' => $data['title'],
+			),
+			array(
+				'Field' => 'Timing',
+				'Value' => $data['timing'] . ' (' . $data['label'] . ')',
+			),
+			array(
+				'Field' => 'Attendance',
+				'Value' => $count_label,
+			),
 		);
 
 		WP_CLI\Utils\format_items( 'table', $rows, array( 'Field', 'Value' ) );

--- a/inc/Commands/Events/LocationCommand.php
+++ b/inc/Commands/Events/LocationCommand.php
@@ -723,7 +723,8 @@ class LocationCommand {
 					continue;
 				}
 
-				$ext  = pathinfo( $src, PATHINFO_EXTENSION ) ?: 'png';
+				$ext  = pathinfo( $src, PATHINFO_EXTENSION );
+				$ext  = $ext ? $ext : 'png';
 				$dest = sprintf( '%s/roundup-slide-%d.%s', $output_dir, $i + 1, $ext );
 
 				if ( ! copy( $src, $dest ) ) {

--- a/inc/Commands/Events/VenueDiscoveryCommand.php
+++ b/inc/Commands/Events/VenueDiscoveryCommand.php
@@ -108,7 +108,7 @@ class VenueDiscoveryCommand {
 			$rows[] = array(
 				'name'     => $venue['name'],
 				'address'  => mb_substr( $venue['address'], 0, 45 ),
-				'website'  => $venue['website'] ?: '(none)',
+				'website'  => $venue['website'] ? $venue['website'] : '(none)',
 				'known'    => $venue['is_known'] ? 'yes' : 'NEW',
 			);
 		}
@@ -216,7 +216,7 @@ class VenueDiscoveryCommand {
 			WP_CLI::log( '' );
 			WP_CLI::log( 'Add this venue with:' );
 			WP_CLI::log( sprintf( '  wp extrachill venues add --pipeline=<id> --name="%s" --events-url="%s"',
-				$result['name'] ?: '(venue name)',
+				$result['name'] ? $result['name'] : '(venue name)',
 				$result['events_url']
 			) );
 		} else {

--- a/inc/Commands/Giveaway/GiveawayCommand.php
+++ b/inc/Commands/Giveaway/GiveawayCommand.php
@@ -134,7 +134,14 @@ class GiveawayCommand {
 
 		Utils\format_items( $format, $rows, array( 'rank', 'username', 'comment', 'tags', 'announced' ) );
 
-		$announced_count = count( array_filter( $winners, function ( $w ) { return $w['announced']; } ) );
+		$announced_count = count(
+			array_filter(
+				$winners,
+				function ( $w ) {
+					return $w['announced'];
+				}
+			)
+		);
 		if ( $announced_count > 0 ) {
 			WP_CLI::success( sprintf( '%d winner(s) announced via comment reply.', $announced_count ) );
 		}

--- a/inc/Commands/Newsletter/NewsletterCommand.php
+++ b/inc/Commands/Newsletter/NewsletterCommand.php
@@ -168,7 +168,7 @@ class NewsletterCommand {
 			}
 		}
 
-		if ( $result['failed'] === 0 && empty( $result['dry_run'] ) ) {
+		if ( 0 === $result['failed'] && empty( $result['dry_run'] ) ) {
 			WP_CLI::success( 'Sync complete.' );
 		}
 	}
@@ -262,7 +262,7 @@ class NewsletterCommand {
 				$int_rows[] = array(
 					'Context'    => $context,
 					'Label'     => $integration['label'],
-					'List ID'   => $integration['list_id'] ?: '(not set)',
+					'List ID'   => $integration['list_id'] ? $integration['list_id'] : '(not set)',
 					'Configured' => $integration['list_id_set'] ? 'Yes' : 'No',
 				);
 			}

--- a/inc/Commands/Users/ArtistAccessCommand.php
+++ b/inc/Commands/Users/ArtistAccessCommand.php
@@ -170,13 +170,16 @@ class ArtistAccessCommand {
 	 */
 	private function resolve_user( string $identifier ): ?\WP_User {
 		if ( is_numeric( $identifier ) ) {
-			return get_user_by( 'ID', absint( $identifier ) ) ?: null;
+			$user = get_user_by( 'ID', absint( $identifier ) );
+			return $user ? $user : null;
 		}
 
 		if ( is_email( $identifier ) ) {
-			return get_user_by( 'email', $identifier ) ?: null;
+			$user = get_user_by( 'email', $identifier );
+			return $user ? $user : null;
 		}
 
-		return get_user_by( 'login', $identifier ) ?: null;
+		$user = get_user_by( 'login', $identifier );
+		return $user ? $user : null;
 	}
 }

--- a/inc/Commands/Users/ProfileCommand.php
+++ b/inc/Commands/Users/ProfileCommand.php
@@ -63,14 +63,38 @@ class ProfileCommand {
 		if ( 'table' === $format ) {
 			$links_count = isset( $result['links'] ) ? count( $result['links'] ) : 0;
 			$fields = array(
-				array( 'Field' => 'user_id', 'Value' => $result['user_id'] ),
-				array( 'Field' => 'display_name', 'Value' => $result['display_name'] ),
-				array( 'Field' => 'username', 'Value' => $result['username'] ),
-				array( 'Field' => 'custom_title', 'Value' => $result['custom_title'] ?: '(default)' ),
-				array( 'Field' => 'bio', 'Value' => mb_substr( $result['bio'] ?? '', 0, 80 ) . ( mb_strlen( $result['bio'] ?? '' ) > 80 ? '...' : '' ) ),
-				array( 'Field' => 'local_city', 'Value' => $result['local_city'] ?: '(none)' ),
-				array( 'Field' => 'links', 'Value' => $links_count . ' link(s)' ),
-				array( 'Field' => 'artist_status', 'Value' => $result['artist_access']['status'] ?? 'none' ),
+				array(
+					'Field' => 'user_id',
+					'Value' => $result['user_id'],
+				),
+				array(
+					'Field' => 'display_name',
+					'Value' => $result['display_name'],
+				),
+				array(
+					'Field' => 'username',
+					'Value' => $result['username'],
+				),
+				array(
+					'Field' => 'custom_title',
+					'Value' => $result['custom_title'] ? $result['custom_title'] : '(default)',
+				),
+				array(
+					'Field' => 'bio',
+					'Value' => mb_substr( $result['bio'] ?? '', 0, 80 ) . ( mb_strlen( $result['bio'] ?? '' ) > 80 ? '...' : '' ),
+				),
+				array(
+					'Field' => 'local_city',
+					'Value' => $result['local_city'] ? $result['local_city'] : '(none)',
+				),
+				array(
+					'Field' => 'links',
+					'Value' => $links_count . ' link(s)',
+				),
+				array(
+					'Field' => 'artist_status',
+					'Value' => $result['artist_access']['status'] ?? 'none',
+				),
 			);
 			WP_CLI\Utils\format_items( 'table', $fields, array( 'Field', 'Value' ) );
 		} else {

--- a/inc/Commands/Users/SettingsCommand.php
+++ b/inc/Commands/Users/SettingsCommand.php
@@ -62,13 +62,34 @@ class SettingsCommand {
 
 		if ( 'table' === $format ) {
 			$fields = array(
-				array( 'Field' => 'user_id', 'Value' => $result['user_id'] ),
-				array( 'Field' => 'first_name', 'Value' => $result['first_name'] ),
-				array( 'Field' => 'last_name', 'Value' => $result['last_name'] ),
-				array( 'Field' => 'display_name', 'Value' => $result['display_name'] ),
-				array( 'Field' => 'email', 'Value' => $result['email'] ),
-				array( 'Field' => 'pending_email', 'Value' => $result['pending_email'] ?? '(none)' ),
-				array( 'Field' => 'display_name_options', 'Value' => implode( ', ', $result['display_name_options'] ) ),
+				array(
+					'Field' => 'user_id',
+					'Value' => $result['user_id'],
+				),
+				array(
+					'Field' => 'first_name',
+					'Value' => $result['first_name'],
+				),
+				array(
+					'Field' => 'last_name',
+					'Value' => $result['last_name'],
+				),
+				array(
+					'Field' => 'display_name',
+					'Value' => $result['display_name'],
+				),
+				array(
+					'Field' => 'email',
+					'Value' => $result['email'],
+				),
+				array(
+					'Field' => 'pending_email',
+					'Value' => $result['pending_email'] ?? '(none)',
+				),
+				array(
+					'Field' => 'display_name_options',
+					'Value' => implode( ', ', $result['display_name_options'] ),
+				),
 			);
 			WP_CLI\Utils\format_items( 'table', $fields, array( 'Field', 'Value' ) );
 		} else {


### PR DESCRIPTION
## Summary

Clears all pre-existing phpcs lint debt in `extrachill-cli` so `homeboy release` no longer needs `--skip-checks` to pass the lint preflight error gate. **Formatting-only — zero behavior changes.**

## Before / after (phpcs errors)

| | Before | After |
|---|---|---|
| **phpcs errors** | **69** | **0** |

Final clean run against this branch:

```
LINT SUMMARY: 0 errors, 56 warnings
Fixable: 36 | Files with issues: 11 of 19
```

(The 56 warnings are pre-existing non-blocking phpcs warnings; the 37 phpstan findings are a separate static-analysis layer, out of scope here and untouched by these formatting changes.)

## Error breakdown fixed (69 total)

| Count | Rule | Fix |
|---|---|---|
| 44 | `WordPress.Arrays.ArrayDeclarationSpacing.AssociativeArrayFound` | Split inline associative arrays to one element per line |
| 11 | `WordPress.PHP.YodaConditions.NotYoda` | Reordered comparisons to Yoda form |
| 10 | `Universal.Operators.DisallowShortTernary.Found` | Expanded `?:` to full ternary (captured operands in temp vars where the left side was a function call, to preserve single-evaluation semantics) |
| 2 | `Squiz.PHP.DisallowSizeFunctionsInLoops.Found` | Hoisted `count()` out of `while` conditions; recompute inside loop body to preserve identical iteration behavior |
| 1 | `Generic.Formatting.DisallowMultipleStatements.SameLine` | Split inline closure body across lines |
| 1 | `PSR2.Classes.ClassDeclaration.CloseBraceAfterBody` | Removed blank line before class close brace |

## Verification

- `homeboy lint extrachill-cli --path <worktree>` → **0 phpcs errors**
- `php -l` clean on all 12 changed files
- `git diff` is formatting-only — no logic, no signature, no control-flow changes
- No `composer.json` / `composer.lock` changes (used homeboy's bundled phpcs tooling)

## Notes

- The `--short-ternary` and `count()`-in-loop fixes were done with temp variables rather than naive inline rewrites specifically to **avoid double-evaluating** function calls / re-running DB lookups — keeping runtime behavior byte-for-byte identical.