### PR TITLE
refactor(notifications): repoint CLI community notifications to network substrate

### DIFF
--- a/inc/Commands/Community/CommunityCommand.php
+++ b/inc/Commands/Community/CommunityCommand.php
@@ -294,10 +294,16 @@ class CommunityCommand {
 	 * [--clear-all]
 	 * : Clear ALL notifications.
 	 *
-	 * [--limit=<limit>]
-	 * : Max notifications to show.
+	 * [--per-page=<per-page>]
+	 * : Max notifications to show per page.
 	 * ---
 	 * default: 50
+	 * ---
+	 *
+	 * [--page=<page>]
+	 * : Page of notifications to show.
+	 * ---
+	 * default: 1
 	 * ---
 	 *
 	 * [--format=<format>]
@@ -329,9 +335,9 @@ class CommunityCommand {
 
 		// Handle --mark-read.
 		if ( Utils\get_flag_value( $assoc_args, 'mark-read', false ) ) {
-			$ability = wp_get_ability( 'extrachill/community-mark-notifications-read' );
+			$ability = wp_get_ability( 'extrachill/mark-notifications-read' );
 			if ( ! $ability ) {
-				WP_CLI::error( 'extrachill/community-mark-notifications-read ability not available.' );
+				WP_CLI::error( 'extrachill/mark-notifications-read ability not available.' );
 			}
 
 			$result = $ability->execute( array( 'user_id' => $user_id ) );
@@ -345,9 +351,9 @@ class CommunityCommand {
 
 		// Handle --clear / --clear-all.
 		if ( Utils\get_flag_value( $assoc_args, 'clear', false ) || Utils\get_flag_value( $assoc_args, 'clear-all', false ) ) {
-			$ability = wp_get_ability( 'extrachill/community-clear-notifications' );
+			$ability = wp_get_ability( 'extrachill/clear-notifications' );
 			if ( ! $ability ) {
-				WP_CLI::error( 'extrachill/community-clear-notifications ability not available.' );
+				WP_CLI::error( 'extrachill/clear-notifications ability not available.' );
 			}
 
 			$clear_all = Utils\get_flag_value( $assoc_args, 'clear-all', false );
@@ -367,20 +373,22 @@ class CommunityCommand {
 		}
 
 		// Default: list notifications.
-		$ability = wp_get_ability( 'extrachill/community-get-notifications' );
+		$ability = wp_get_ability( 'extrachill/get-notifications' );
 		if ( ! $ability ) {
-			WP_CLI::error( 'extrachill/community-get-notifications ability not available.' );
+			WP_CLI::error( 'extrachill/get-notifications ability not available.' );
 		}
 
-		$unread = Utils\get_flag_value( $assoc_args, 'unread', false );
-		$limit  = isset( $assoc_args['limit'] ) ? (int) $assoc_args['limit'] : 50;
-		$format = isset( $assoc_args['format'] ) ? (string) $assoc_args['format'] : 'table';
+		$unread   = Utils\get_flag_value( $assoc_args, 'unread', false );
+		$per_page = isset( $assoc_args['per-page'] ) ? (int) $assoc_args['per-page'] : 50;
+		$page     = isset( $assoc_args['page'] ) ? (int) $assoc_args['page'] : 1;
+		$format   = isset( $assoc_args['format'] ) ? (string) $assoc_args['format'] : 'table';
 
 		$result = $ability->execute(
 			array(
-				'user_id' => $user_id,
-				'unread'  => $unread,
-				'limit'   => $limit,
+				'user_id'  => $user_id,
+				'unread'   => $unread,
+				'page'     => $page,
+				'per_page' => $per_page,
 			)
 		);
 
@@ -410,11 +418,11 @@ class CommunityCommand {
 		$rows = array();
 		foreach ( $result['notifications'] as $n ) {
 			$rows[] = array(
-				'type'        => isset( $n['type'] ) ? $n['type'] : '',
-				'from'        => isset( $n['actor_display_name'] ) ? $n['actor_display_name'] : '',
-				'subject'     => isset( $n['topic_title'] ) ? mb_substr( $n['topic_title'], 0, 50 ) : '',
-				'time'        => isset( $n['time'] ) ? $n['time'] : '',
-				'read'        => empty( $n['read'] ) ? 'no' : 'yes',
+				'type'    => isset( $n['type'] ) ? $n['type'] : '',
+				'from'    => isset( $n['actor_display_name'] ) ? $n['actor_display_name'] : '',
+				'subject' => isset( $n['title'] ) ? mb_substr( $n['title'], 0, 50 ) : '',
+				'time'    => isset( $n['time'] ) ? $n['time'] : '',
+				'read'    => empty( $n['read'] ) ? 'no' : 'yes',
 			);
 		}
 


### PR DESCRIPTION
## Summary

Repoints the `wp extrachill community notifications` subcommand off the old community-only blob abilities (being deleted in parallel cutover PRs) and onto the new **network-wide notification substrate** abilities registered by `extrachill-users` (`Network: true`).

Part of epic Extra-Chill/extrachill-community#82.

## Ability repoint

| Old (deleted) | New (substrate) |
|---|---|
| `extrachill/community-get-notifications` | `extrachill/get-notifications` |
| `extrachill/community-mark-notifications-read` | `extrachill/mark-notifications-read` |
| `extrachill/community-clear-notifications` | `extrachill/clear-notifications` |

## Contract changes

- **`limit` -> `per_page`**: the substrate `get-notifications` ability paginates with `page`/`per_page` (default 50), not a flat `limit`. The CLI flag is now `--per-page` and a new `--page` flag was added. Output still exposes `notifications[]` + `unread_count` + `total`.
- **`topic_title` -> `title`**: the substrate notification row shape uses `title`; the table `subject` column now reads `$n['title']`.
- `--mark-read` calls `mark-notifications-read` with no `notification_id` (the substrate treats `0`/absent as "mark all").
- `--clear` / `--clear-all` map to `clear-notifications` with the `all` flag as before.
- Updated `WP_CLI::error` "ability not available" strings and the docblock `@synopsis` (`--limit` -> `--per-page`, added `--page`) to match.

The command and subcommand names, plus the `--unread` / `--count` / `--mark-read` / `--clear` / `--clear-all` / `--format` UX, are unchanged.

## Verification

- `php -l` clean.
- `homeboy lint --changed-since HEAD`: my changed code adds **zero** new findings and actually clears 5 pre-existing array-alignment findings in the touched block. Remaining findings on the file are pre-existing repo lint debt (phpstan `WP_User|false` narrowing, unused-param notices, a phpcs false-positive comment) on lines this PR does not introduce.
- Grep-confirmed: **zero** remaining references to the 3 old ability names and zero `topic_title` in the notifications command.

## Dependencies / coordination

- **Depends on** the merged `extrachill-users` network notification substrate (registers the new abilities).
- **Coordinates with** the community + api cutover PRs that delete the old `community-*-notifications` abilities. This PR must not land before those abilities exist on the substrate (already merged) — and the old ones can be deleted once all consumers (this CLI included) are repointed.