### PR TITLE
fix(agents-md): generate Extra Chill CLI section from real command tree (#28)

### DIFF
--- a/extrachill-cli.php
+++ b/extrachill-cli.php
@@ -34,30 +34,17 @@ add_action( 'plugins_loaded', function () {
 		return;
 	}
 
+	// This section can be composed in non-CLI (web/cron) contexts where the
+	// WP_CLI guard below has not registered the autoloader. Register it here
+	// so the generator can reflect over the real command classes (and any
+	// traits they use) regardless of context.
+	require_once EXTRACHILL_CLI_PATH . 'inc/Autoloader.php';
+	\ExtraChill\CLI\Autoloader::register( EXTRACHILL_CLI_PATH );
+
 	$wp = 'wp --allow-root --path=' . ABSPATH;
 
 	\DataMachine\Engine\AI\SectionRegistry::register( 'AGENTS.md', 'extrachill-cli', 50, function () use ( $wp ) {
-		return <<<MD
-### Extra Chill CLI
-
-Platform-specific tooling wrapping common operations into unified commands.
-Discover everything: `{$wp} extrachill --help`
-
-- `{$wp} extrachill artists` — artist profile management and search
-- `{$wp} extrachill events` — events calendar operations
-- `{$wp} extrachill seo` — SEO audit, meta tags, and structured data
-- `{$wp} extrachill analytics` — analytics and traffic reports
-- `{$wp} extrachill newsletter` — newsletter campaigns and Sendy integration
-- `{$wp} extrachill community` — community forum operations
-- `{$wp} extrachill users` — user management and team membership
-- `{$wp} extrachill venues` — venue lookups
-- `{$wp} extrachill shows` — show/concert operations
-- `{$wp} extrachill cache` — object cache and page cache management
-- `{$wp} extrachill tools` — miscellaneous platform tools
-- `{$wp} extrachill giveaway` — giveaway management
-
-All commands support `--help` for subcommand discovery.
-MD;
+		return \ExtraChill\CLI\AgentsMdSection::render( $wp );
 	}, array(
 		'label'       => 'Extra Chill CLI',
 		'description' => 'Platform-specific WP-CLI commands for Extra Chill.',
@@ -70,23 +57,8 @@ if ( ! defined( 'WP_CLI' ) || ! WP_CLI ) {
 }
 
 // PSR-4 autoloader for ExtraChill\CLI namespace.
-spl_autoload_register(
-	function ( $class_name ) {
-		$prefix = 'ExtraChill\\CLI\\';
-		$len    = strlen( $prefix );
-
-		if ( strncmp( $prefix, $class_name, $len ) !== 0 ) {
-			return;
-		}
-
-		$relative = substr( $class_name, $len );
-		$file     = EXTRACHILL_CLI_PATH . 'inc/' . str_replace( '\\', '/', $relative ) . '.php';
-
-		if ( file_exists( $file ) ) {
-			require_once $file;
-		}
-	}
-);
+require_once EXTRACHILL_CLI_PATH . 'inc/Autoloader.php';
+\ExtraChill\CLI\Autoloader::register( EXTRACHILL_CLI_PATH );
 
 // Register commands.
 require_once EXTRACHILL_CLI_PATH . 'inc/bootstrap.php';

--- a/inc/AgentsMdSection.php
+++ b/inc/AgentsMdSection.php
@@ -1,0 +1,232 @@
+<?php
+/**
+ * AGENTS.md Section Generator
+ *
+ * Generates the "Extra Chill CLI" section of the composed AGENTS.md file by
+ * introspecting the real registered command tree instead of hand-maintaining
+ * a heredoc. Walks every command registered in CommandRegistry, reflects over
+ * each command class's public methods, and emits each namespace with its real
+ * subcommands and their PHPDoc short descriptions.
+ *
+ * Context-safe: the section callback runs on `plugins_loaded` in web/cron
+ * compose contexts where the WP-CLI runtime and the plugin's PSR-4 autoloader
+ * (both guarded by `if ( WP_CLI )`) are NOT loaded. This generator therefore
+ * resolves command class files directly from disk via the same PSR-4 layout
+ * and reflects over the class files, never relying on the live WP-CLI runner.
+ *
+ * Pending Extra-Chill/data-machine#2613: once that shared
+ * `CliCommandIntrospector` helper lands, this class can delegate the
+ * reflection/parsing to it and keep only the CommandRegistry map local.
+ *
+ * @package ExtraChill\CLI
+ */
+
+namespace ExtraChill\CLI;
+
+use ReflectionClass;
+use ReflectionMethod;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+class AgentsMdSection {
+
+	/**
+	 * Build the Markdown body for the Extra Chill CLI AGENTS.md section.
+	 *
+	 * @param string $wp The `wp --allow-root --path=...` invocation prefix.
+	 * @return string
+	 */
+	public static function render( $wp ) {
+		$lines   = array();
+		$lines[] = '### Extra Chill CLI';
+		$lines[] = '';
+		$lines[] = 'Platform-specific tooling wrapping common operations into unified commands.';
+		$lines[] = "Discover everything: `{$wp} extrachill --help`";
+		$lines[] = '';
+
+		foreach ( self::collect_commands() as $command => $subcommands ) {
+			// Strip the leading "extrachill " for the human-readable summary,
+			// but keep the full invocation in the code span.
+			$summary = self::summarize_subcommands( $subcommands );
+
+			if ( '' !== $summary ) {
+				$lines[] = "- `{$wp} {$command}` — {$summary}";
+			} else {
+				$lines[] = "- `{$wp} {$command}`";
+			}
+
+			foreach ( $subcommands as $sub ) {
+				if ( '__default' === $sub['name'] ) {
+					continue;
+				}
+				$desc = $sub['description'];
+				if ( '' !== $desc ) {
+					$lines[] = "  - `{$sub['name']}` — {$desc}";
+				} else {
+					$lines[] = "  - `{$sub['name']}`";
+				}
+			}
+		}
+
+		$lines[] = '';
+		$lines[] = 'All commands support `--help` for full options and subcommand discovery.';
+
+		return implode( "\n", $lines );
+	}
+
+	/**
+	 * Walk the CommandRegistry and reflect each class into its subcommands.
+	 *
+	 * @return array<string, array<int, array{name:string, description:string}>>
+	 *               command string => ordered list of subcommands.
+	 */
+	private static function collect_commands() {
+		$out = array();
+
+		foreach ( CommandRegistry::map() as $command => $class ) {
+			$subcommands = self::reflect_subcommands( $class );
+			$out[ $command ] = $subcommands;
+		}
+
+		return $out;
+	}
+
+	/**
+	 * Reflect a command class into its list of public subcommands.
+	 *
+	 * Public methods are WP-CLI subcommands. The subcommand name is taken from
+	 * the `@subcommand <name>` annotation when present, otherwise the method
+	 * name with underscores converted to hyphens (WP-CLI's own convention).
+	 * `__invoke` / `@subcommand __default` represent the directly-invokable
+	 * namespace itself. Private, protected, static, and magic helper methods
+	 * are skipped.
+	 *
+	 * @param class-string $class Command class.
+	 * @return array<int, array{name:string, description:string}>
+	 */
+	private static function reflect_subcommands( $class ) {
+		// The autoloader (registered before this section is composed) resolves
+		// the class file and any traits it uses; class_exists triggers it.
+		if ( ! class_exists( $class ) ) {
+			return array();
+		}
+
+		try {
+			$reflection = new ReflectionClass( $class );
+		} catch ( \Throwable $e ) {
+			return array();
+		}
+
+		$subcommands = array();
+
+		foreach ( $reflection->getMethods( ReflectionMethod::IS_PUBLIC ) as $method ) {
+			// Only methods declared on the command class itself.
+			if ( $method->getDeclaringClass()->getName() !== $reflection->getName() ) {
+				continue;
+			}
+
+			if ( $method->isStatic() || $method->isConstructor() || $method->isDestructor() ) {
+				continue;
+			}
+
+			$method_name = $method->getName();
+			$doc         = $method->getDocComment() ?: '';
+
+			// `__invoke` (or any method tagged @subcommand __default) maps to
+			// the namespace itself, so it has no sub-word.
+			$annotated = self::parse_subcommand_annotation( $doc );
+
+			if ( '__invoke' === $method_name && '' === $annotated ) {
+				$annotated = '__default';
+			}
+
+			if ( '' !== $annotated ) {
+				$name = $annotated;
+			} else {
+				// Skip other magic methods that are not subcommands.
+				if ( 0 === strpos( $method_name, '__' ) ) {
+					continue;
+				}
+				$name = str_replace( '_', '-', $method_name );
+			}
+
+			$subcommands[] = array(
+				'name'        => $name,
+				'description' => self::parse_short_description( $doc ),
+			);
+		}
+
+		return $subcommands;
+	}
+
+	/**
+	 * Build a comma-separated summary of subcommand names for the headline.
+	 *
+	 * @param array<int, array{name:string, description:string}> $subcommands Subcommands.
+	 * @return string
+	 */
+	private static function summarize_subcommands( $subcommands ) {
+		$names = array();
+		foreach ( $subcommands as $sub ) {
+			if ( '__default' === $sub['name'] ) {
+				continue;
+			}
+			$names[] = $sub['name'];
+		}
+
+		return implode( ', ', $names );
+	}
+
+	/**
+	 * Parse the `@subcommand <name>` annotation from a docblock.
+	 *
+	 * @param string $doc Raw docblock.
+	 * @return string Subcommand name, or '' when not annotated.
+	 */
+	private static function parse_subcommand_annotation( $doc ) {
+		if ( preg_match( '/@subcommand\s+(\S+)/', $doc, $m ) ) {
+			return $m[1];
+		}
+		return '';
+	}
+
+	/**
+	 * Parse the short description (first prose line) from a docblock.
+	 *
+	 * Mirrors how WP-CLI derives a command's summary for `--help`: the first
+	 * non-empty content line of the docblock, before any `## SECTION` heading.
+	 *
+	 * @param string $doc Raw docblock.
+	 * @return string
+	 */
+	private static function parse_short_description( $doc ) {
+		if ( '' === $doc ) {
+			return '';
+		}
+
+		// Strip the comment framing.
+		$doc   = preg_replace( '#^/\*\*|\*/$#', '', $doc );
+		$lines = preg_split( '/\r\n|\r|\n/', $doc );
+
+		foreach ( $lines as $line ) {
+			$line = preg_replace( '/^\s*\*\s?/', '', $line );
+			$line = trim( $line );
+
+			if ( '' === $line ) {
+				continue;
+			}
+
+			// Stop at structured sections / annotations.
+			if ( 0 === strpos( $line, '##' ) || 0 === strpos( $line, '@' ) ) {
+				return '';
+			}
+
+			// Drop a trailing period for a tighter inline summary.
+			return rtrim( $line, '.' );
+		}
+
+		return '';
+	}
+}

--- a/inc/Autoloader.php
+++ b/inc/Autoloader.php
@@ -1,0 +1,61 @@
+<?php
+/**
+ * PSR-4 Autoloader
+ *
+ * Registers a namespace-scoped autoloader for the `ExtraChill\CLI\` namespace
+ * rooted at the plugin's `inc/` directory. Used in both the WP-CLI runtime
+ * (to load command classes on demand) and in non-CLI compose contexts (so the
+ * AGENTS.md section generator can reflect over command classes and resolve
+ * any traits or dependencies they `use` without a fatal error).
+ *
+ * @package ExtraChill\CLI
+ */
+
+namespace ExtraChill\CLI;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+class Autoloader {
+
+	/**
+	 * Whether the autoloader has already been registered this request.
+	 *
+	 * @var bool
+	 */
+	private static $registered = false;
+
+	/**
+	 * Register the PSR-4 autoloader (idempotent).
+	 *
+	 * @param string $base_path Plugin root path (with trailing slash).
+	 * @return void
+	 */
+	public static function register( $base_path ) {
+		if ( self::$registered ) {
+			return;
+		}
+		self::$registered = true;
+
+		$inc = rtrim( $base_path, '/' ) . '/inc/';
+
+		spl_autoload_register(
+			function ( $class_name ) use ( $inc ) {
+				$prefix = 'ExtraChill\\CLI\\';
+				$len    = strlen( $prefix );
+
+				if ( strncmp( $prefix, $class_name, $len ) !== 0 ) {
+					return;
+				}
+
+				$relative = substr( $class_name, $len );
+				$file     = $inc . str_replace( '\\', '/', $relative ) . '.php';
+
+				if ( file_exists( $file ) ) {
+					require_once $file;
+				}
+			}
+		);
+	}
+}

--- a/inc/CommandRegistry.php
+++ b/inc/CommandRegistry.php
@@ -1,0 +1,72 @@
+<?php
+/**
+ * Command Registry
+ *
+ * Single source of truth mapping `wp extrachill ...` command strings to their
+ * implementing command classes. Both the WP-CLI bootstrap (which calls
+ * WP_CLI::add_command for each entry) and the AGENTS.md section generator
+ * (which reflects over each class to enumerate real subcommands) read from
+ * this map, so the documented CLI surface can never drift from what is
+ * actually registered.
+ *
+ * @package ExtraChill\CLI
+ */
+
+namespace ExtraChill\CLI;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+class CommandRegistry {
+
+	/**
+	 * Map of command string => fully-qualified command class.
+	 *
+	 * Keys are the exact strings passed to WP_CLI::add_command (the command
+	 * namespace, e.g. "extrachill venues" or "extrachill users access").
+	 * Order here determines both registration order and documentation order.
+	 *
+	 * @return array<string, class-string>
+	 */
+	public static function map() {
+		return array(
+			// Analytics commands.
+			'extrachill analytics summary' => Commands\Analytics\SummaryCommand::class,
+			'extrachill analytics 404'     => Commands\Analytics\FourOhFourCommand::class,
+			'extrachill analytics attacks' => Commands\Analytics\AttacksCommand::class,
+
+			// Events commands.
+			'extrachill events' => Commands\Events\LocationCommand::class,
+			'extrachill venues' => Commands\Events\VenueDiscoveryCommand::class,
+			'extrachill shows'  => Commands\Events\ConcertTrackingCommand::class,
+
+			// SEO commands.
+			'extrachill seo redirects' => Commands\SEO\RedirectsCommand::class,
+
+			// Tools commands.
+			'extrachill tools qr' => Commands\Tools\QRCodeCommand::class,
+
+			// Artists commands.
+			'extrachill artists' => Commands\Artists\ArtistCommand::class,
+
+			// Users commands.
+			'extrachill users'          => Commands\Users\BanCommand::class,
+			'extrachill users access'   => Commands\Users\ArtistAccessCommand::class,
+			'extrachill users settings' => Commands\Users\SettingsCommand::class,
+			'extrachill users profile'  => Commands\Users\ProfileCommand::class,
+
+			// Community commands.
+			'extrachill community' => Commands\Community\CommunityCommand::class,
+
+			// Cache commands.
+			'extrachill cache' => Commands\Cache\WarmCommand::class,
+
+			// Giveaway commands.
+			'extrachill giveaway' => Commands\Giveaway\GiveawayCommand::class,
+
+			// Newsletter commands.
+			'extrachill newsletter' => Commands\Newsletter\NewsletterCommand::class,
+		);
+	}
+}

--- a/inc/bootstrap.php
+++ b/inc/bootstrap.php
@@ -17,39 +17,9 @@ if ( ! defined( 'WP_CLI' ) || ! WP_CLI ) {
 	return;
 }
 
-// Analytics commands.
-WP_CLI::add_command( 'extrachill analytics summary', ExtraChill\CLI\Commands\Analytics\SummaryCommand::class );
-WP_CLI::add_command( 'extrachill analytics 404', ExtraChill\CLI\Commands\Analytics\FourOhFourCommand::class );
-WP_CLI::add_command( 'extrachill analytics attacks', ExtraChill\CLI\Commands\Analytics\AttacksCommand::class );
-
-// Events commands.
-WP_CLI::add_command( 'extrachill events', ExtraChill\CLI\Commands\Events\LocationCommand::class );
-WP_CLI::add_command( 'extrachill venues', ExtraChill\CLI\Commands\Events\VenueDiscoveryCommand::class );
-WP_CLI::add_command( 'extrachill shows', ExtraChill\CLI\Commands\Events\ConcertTrackingCommand::class );
-
-// SEO commands.
-WP_CLI::add_command( 'extrachill seo redirects', ExtraChill\CLI\Commands\SEO\RedirectsCommand::class );
-
-// Tools commands.
-WP_CLI::add_command( 'extrachill tools qr', ExtraChill\CLI\Commands\Tools\QRCodeCommand::class );
-
-// Artists commands.
-WP_CLI::add_command( 'extrachill artists', ExtraChill\CLI\Commands\Artists\ArtistCommand::class );
-
-// Users commands.
-WP_CLI::add_command( 'extrachill users', ExtraChill\CLI\Commands\Users\BanCommand::class );
-WP_CLI::add_command( 'extrachill users access', ExtraChill\CLI\Commands\Users\ArtistAccessCommand::class );
-WP_CLI::add_command( 'extrachill users settings', ExtraChill\CLI\Commands\Users\SettingsCommand::class );
-WP_CLI::add_command( 'extrachill users profile', ExtraChill\CLI\Commands\Users\ProfileCommand::class );
-
-// Community commands.
-WP_CLI::add_command( 'extrachill community', ExtraChill\CLI\Commands\Community\CommunityCommand::class );
-
-// Cache commands.
-WP_CLI::add_command( 'extrachill cache', ExtraChill\CLI\Commands\Cache\WarmCommand::class );
-
-// Giveaway commands.
-WP_CLI::add_command( 'extrachill giveaway', ExtraChill\CLI\Commands\Giveaway\GiveawayCommand::class );
-
-// Newsletter commands.
-WP_CLI::add_command( 'extrachill newsletter', ExtraChill\CLI\Commands\Newsletter\NewsletterCommand::class );
+// Register every command from the single-source-of-truth map. The same map
+// drives the AGENTS.md section generator, so documentation cannot drift from
+// what is actually registered here.
+foreach ( ExtraChill\CLI\CommandRegistry::map() as $command => $command_class ) {
+	WP_CLI::add_command( $command, $command_class );
+}


### PR DESCRIPTION
## Summary

Fixes #28. The AGENTS.md **Extra Chill CLI** section was a hand-written heredoc that drifted from the actually-registered commands — most egregiously listing `venues — venue lookups` when the `venues` namespace actually exposes `discover` / `qualify` / `add`. That wrong sketch was worse than no map: it actively signaled "nothing to see here" for a fully-built capability.

This PR implements the issue's **preferred Option B**: the section body is now **generated from the real command tree** via reflection, not maintained by hand.

## How it works

```
CommandRegistry::map()          single source of truth: command string => class
        │
        ├──> bootstrap.php       WP_CLI::add_command() for each entry (registration)
        │
        └──> AgentsMdSection     reflects each class's public methods, reads
                                 @subcommand + PHPDoc short description (docs)
```

- **`inc/CommandRegistry.php`** — the one map of `wp extrachill ...` → command class. `bootstrap.php` now registers from it, so registration and documentation read the same truth. Adding a command in one place surfaces it in both.
- **`inc/AgentsMdSection.php`** — reflects over each registered command class's public methods, derives the subcommand name from `@subcommand <name>` (falling back to the method name with `_`→`-`, matching WP-CLI), and pulls the first PHPDoc line as the short description. `__invoke` / `@subcommand __default` map to the directly-invokable namespace.
- **`inc/Autoloader.php`** — extracted the PSR-4 autoloader so it can be registered in **non-CLI compose/cron/web contexts** too. The section callback runs on `plugins_loaded` outside the `if ( WP_CLI )` guard, and the command classes `use` traits — so reflection needs the autoloader available to resolve both classes and their traits. Verified the generator produces full output with `WP_CLI` undefined.

## Verification

`php -l` clean on all changed/new files. All 17 registered command classes resolve through the registry. The generator was exercised directly through its `AgentsMdSection::render()` entry point (the same call the `SectionRegistry` callback makes) in a simulated **non-CLI** context (`WP_CLI` undefined) — this is the faithful test of the compose path, since `datamachine memory compose` on production reads the *deployed* plugin (still the old heredoc until this is deployed). Regenerated section below — note `venues` now correctly lists `discover / qualify / add`:

```
### Extra Chill CLI

Platform-specific tooling wrapping common operations into unified commands.
Discover everything: `wp --allow-root --path=/var/www/extrachill.com/ extrachill --help`

- `wp ... extrachill analytics summary`
- `wp ... extrachill analytics 404` — list, top, patterns, drill, summary, purge, top-ips
  - `list` — List recent 404 errors
  - `top` — Show top 404 URLs by hit count
  - `patterns` — Show 404 errors grouped by pattern category
  - `drill` — Show top 404 URLs for a specific pattern category
  - `summary` — Show summary statistics for 404 errors
  - `purge` — Purge 404 error events older than a given number of days
  - `top-ips` — Show top IP addresses generating 404 errors
- `wp ... extrachill analytics attacks`
- `wp ... extrachill events` — audit-locations, fix-locations, market-report, audit-times, fix-times, roundup
  - `audit-locations` — Audit event location assignments against venue city
  - `fix-locations` — Fix event location assignments to match venue city
  - `market-report` — Generate a market overview report for event calendar locations
  - `audit-times` — Audit event times for timezone mismatches and suspicious values
  - `fix-times` — Fix event times by converting between timezones
  - `roundup` — Generate an event roundup carousel graphic for a date range
- `wp ... extrachill venues` — discover, qualify, add
  - `discover` — Discover music venues in a city using Google Places API
  - `qualify` — Qualify a venue website — find its events page and check for scrapable listings
  - `add` — Add a venue scraper flow to an existing city pipeline
- `wp ... extrachill shows` — mark, unmark, check, list, stats, event, import
  - `mark` — Mark an event for a user (Going / Check In / I Was There)
  - `unmark` — Unmark an event for a user
  - `check` — Check if a user has marked an event
  - `list`
  - `stats` — Show aggregate concert stats for a user
  - `event` — Show attendance info for a specific event
  - `import` — Bulk import event marks for a user (backfill concert history)
- `wp ... extrachill seo redirects` — list, add, remove, test, import
  - `list` — List redirect rules
  - `add` — Add a redirect rule
  - `remove` — Remove a redirect rule
  - `test` — Test a URL against the redirect rules table
  - `import` — Import redirects from 404 analysis
- `wp ... extrachill tools qr` — generate
  - `generate` — Generate a QR code PNG for a URL
- `wp ... extrachill artists` — get, create, update, link-page, save-socials, save-links, add-link, remove-link, move-link, save-styles, save-settings
  - (11 subcommands, each with its real PHPDoc summary)
- `wp ... extrachill users` — ban, unban, ban-status
- `wp ... extrachill users access` — list, approve, reject
- `wp ... extrachill users settings` — get, update, change-email, change-password
- `wp ... extrachill users profile` — get, update, update-links
- `wp ... extrachill community` — stats, leaderboard, points, recalculate-all, notifications, forums, toggle-homepage, upvote, topics, topic, create-topic, create-reply, flush-cache
- `wp ... extrachill cache` — warm, status
- `wp ... extrachill giveaway` — run, schedule, resolve
- `wp ... extrachill newsletter` — subscribe, sync, push-campaign, settings, campaigns, campaign, delete-campaign, subscriber-status, subscribers

All commands support `--help` for full options and subcommand discovery.
```

(Full output with every subcommand description was captured in the dev session; truncated here for readability.)

## Dependency

This is a self-contained implementation pending the shared `DataMachine\Engine\AI\CliCommandIntrospector` helper tracked in **Extra-Chill/data-machine#2613** (currently an open issue — the helper class is not yet on data-machine `origin/main`, confirmed by grep of the deployed plugin). Once it lands, `AgentsMdSection` can delegate the reflection/parsing to it and keep only the local `CommandRegistry` map. A note to that effect is in the `AgentsMdSection` docblock.

cc <@1493317298151489577>