### PR TITLE
feat: add `wp extrachill artists stats` measurability command

### DIFF
--- a/inc/Commands/Artists/ArtistCommand.php
+++ b/inc/Commands/Artists/ArtistCommand.php
@@ -894,4 +894,76 @@ class ArtistCommand {
 		}
 		WP_CLI::success( sprintf( 'Updated %d setting(s) for artist %d.', count( $settings ), $artist_id ) );
 	}
+
+	/**
+	 * Show point-in-time artist platform stats.
+	 *
+	 * Thin wrapper over the extrachill/get-artist-platform-stats ability:
+	 * total published artist profiles, total published link pages, profiles
+	 * created in the last N days, and link pages with at least one view or
+	 * click in the last N days.
+	 *
+	 * Funnel conversion-over-time (created / requested / approved counts) is
+	 * read separately via `wp extrachill analytics summary --days=N`, which
+	 * aggregates the analytics events emitted at the funnel's lifecycle points.
+	 *
+	 * ## OPTIONS
+	 *
+	 * [--days=<days>]
+	 * : Window in days for the recent aggregates. 0 disables the recent window.
+	 * ---
+	 * default: 28
+	 * ---
+	 *
+	 * [--format=<format>]
+	 * : Output format.
+	 * ---
+	 * default: table
+	 * options:
+	 *   - table
+	 *   - json
+	 *   - yaml
+	 * ---
+	 *
+	 * ## EXAMPLES
+	 *
+	 *     wp extrachill artists stats
+	 *     wp extrachill artists stats --days=90 --format=json
+	 *
+	 * @subcommand stats
+	 * @when after_wp_load
+	 */
+	public function stats( $args, $assoc_args ) {
+		$days = isset( $assoc_args['days'] ) ? max( 0, (int) $assoc_args['days'] ) : 28;
+
+		$ability = wp_get_ability( 'extrachill/get-artist-platform-stats' );
+		if ( ! $ability ) {
+			WP_CLI::error( 'extrachill/get-artist-platform-stats ability not available.' );
+		}
+
+		$result = $ability->execute( array( 'days' => $days ) );
+
+		if ( is_wp_error( $result ) ) {
+			WP_CLI::error( $result->get_error_message() );
+		}
+
+		$format = $assoc_args['format'] ?? 'table';
+
+		if ( 'json' === $format || 'yaml' === $format ) {
+			Utils\format_items(
+				$format,
+				array( $result ),
+				array_keys( $result )
+			);
+			return;
+		}
+
+		$display = array(
+			array( 'Metric' => 'Total published artist profiles', 'Value' => (string) $result['total_artist_profiles'] ),
+			array( 'Metric' => 'Total published link pages', 'Value' => (string) $result['total_link_pages'] ),
+			array( 'Metric' => sprintf( 'Profiles created (last %d days)', $result['days'] ), 'Value' => (string) $result['profiles_created_recent'] ),
+			array( 'Metric' => sprintf( 'Active link pages (last %d days)', $result['days'] ), 'Value' => (string) $result['active_link_pages_recent'] ),
+		);
+		Utils\format_items( 'table', $display, array( 'Metric', 'Value' ) );
+	}
 }


### PR DESCRIPTION
## Summary
Adds `wp extrachill artists stats [--days=N] [--format=table|json|yaml]` — a **thin** wrapper over the new `extrachill/get-artist-platform-stats` ability (extrachill-artist-platform PR #73). All logic lives in the ability; this command only formats output.

Part of Extra-Chill/extrachill-artist-platform#72 (measurability of the artist funnel).

## What it shows
- Total published artist profiles
- Total published link pages
- Profiles created in last N days
- Link pages with ≥1 view/click in last N days

Funnel **conversion-over-time** (created / requested / approved counts) is read separately via the existing `wp extrachill analytics summary --days=N`, which aggregates the analytics events emitted at the funnel's lifecycle points — no new read surface needed for those.

## Placement / collision note
The `stats` subcommand is added as a new method on the existing `ArtistCommand` class (`extrachill artists stats`), not a new command file — so it does not collide with extrachill-cli issue #31. Single-file change to `inc/Commands/Artists/ArtistCommand.php`. The AGENTS.md CLI section reflects the command tree automatically (no manual section edit).

## Dependency
Requires the `extrachill/get-artist-platform-stats` ability from extrachill-artist-platform PR #73. The command errors cleanly (`ability not available`) if that PR isn't deployed yet.

## Constraints honored
- No release, no deploy — PR only.
- Conventional commit; no CHANGELOG / version edits.
- `php -l` clean.

Refs Extra-Chill/extrachill-artist-platform#72