### PR TITLE
feat: measurability CLI wrappers (artists count, access/team stats)

### DIFF
--- a/inc/CommandRegistry.php
+++ b/inc/CommandRegistry.php
@@ -38,36 +38,37 @@ class CommandRegistry {
 			'extrachill analytics errors'  => Commands\Analytics\ErrorsCommand::class,
 
 			// Events commands.
-			'extrachill events' => Commands\Events\LocationCommand::class,
-			'extrachill venues' => Commands\Events\VenueDiscoveryCommand::class,
-			'extrachill shows'  => Commands\Events\ConcertTrackingCommand::class,
+			'extrachill events'            => Commands\Events\LocationCommand::class,
+			'extrachill venues'            => Commands\Events\VenueDiscoveryCommand::class,
+			'extrachill shows'             => Commands\Events\ConcertTrackingCommand::class,
 
 			// SEO commands.
-			'extrachill seo redirects' => Commands\SEO\RedirectsCommand::class,
+			'extrachill seo redirects'     => Commands\SEO\RedirectsCommand::class,
 
 			// Tools commands.
-			'extrachill tools qr' => Commands\Tools\QRCodeCommand::class,
+			'extrachill tools qr'          => Commands\Tools\QRCodeCommand::class,
 
 			// Artists commands.
-			'extrachill artists' => Commands\Artists\ArtistCommand::class,
+			'extrachill artists'           => Commands\Artists\ArtistCommand::class,
 
 			// Users commands.
-			'extrachill users'          => Commands\Users\BanCommand::class,
-			'extrachill users access'   => Commands\Users\ArtistAccessCommand::class,
-			'extrachill users settings' => Commands\Users\SettingsCommand::class,
-			'extrachill users profile'  => Commands\Users\ProfileCommand::class,
+			'extrachill users'             => Commands\Users\BanCommand::class,
+			'extrachill users access'      => Commands\Users\ArtistAccessCommand::class,
+			'extrachill users team'        => Commands\Users\TeamCommand::class,
+			'extrachill users settings'    => Commands\Users\SettingsCommand::class,
+			'extrachill users profile'     => Commands\Users\ProfileCommand::class,
 
 			// Community commands.
-			'extrachill community' => Commands\Community\CommunityCommand::class,
+			'extrachill community'         => Commands\Community\CommunityCommand::class,
 
 			// Cache commands.
-			'extrachill cache' => Commands\Cache\WarmCommand::class,
+			'extrachill cache'             => Commands\Cache\WarmCommand::class,
 
 			// Giveaway commands.
-			'extrachill giveaway' => Commands\Giveaway\GiveawayCommand::class,
+			'extrachill giveaway'          => Commands\Giveaway\GiveawayCommand::class,
 
 			// Newsletter commands.
-			'extrachill newsletter' => Commands\Newsletter\NewsletterCommand::class,
+			'extrachill newsletter'        => Commands\Newsletter\NewsletterCommand::class,
 		);
 	}
 }

--- a/inc/Commands/Artists/ArtistCommand.php
+++ b/inc/Commands/Artists/ArtistCommand.php
@@ -894,4 +894,76 @@ class ArtistCommand {
 		}
 		WP_CLI::success( sprintf( 'Updated %d setting(s) for artist %d.', count( $settings ), $artist_id ) );
 	}
+
+	/**
+	 * Show point-in-time artist platform stats.
+	 *
+	 * Thin wrapper over the extrachill/get-artist-platform-stats ability:
+	 * total published artist profiles, total published link pages, profiles
+	 * created in the last N days, and link pages with at least one view or
+	 * click in the last N days.
+	 *
+	 * Funnel conversion-over-time (created / requested / approved counts) is
+	 * read separately via `wp extrachill analytics summary --days=N`, which
+	 * aggregates the analytics events emitted at the funnel's lifecycle points.
+	 *
+	 * ## OPTIONS
+	 *
+	 * [--days=<days>]
+	 * : Window in days for the recent aggregates. 0 disables the recent window.
+	 * ---
+	 * default: 28
+	 * ---
+	 *
+	 * [--format=<format>]
+	 * : Output format.
+	 * ---
+	 * default: table
+	 * options:
+	 *   - table
+	 *   - json
+	 *   - yaml
+	 * ---
+	 *
+	 * ## EXAMPLES
+	 *
+	 *     wp extrachill artists stats
+	 *     wp extrachill artists stats --days=90 --format=json
+	 *
+	 * @subcommand stats
+	 * @when after_wp_load
+	 */
+	public function stats( $args, $assoc_args ) {
+		$days = isset( $assoc_args['days'] ) ? max( 0, (int) $assoc_args['days'] ) : 28;
+
+		$ability = wp_get_ability( 'extrachill/get-artist-platform-stats' );
+		if ( ! $ability ) {
+			WP_CLI::error( 'extrachill/get-artist-platform-stats ability not available.' );
+		}
+
+		$result = $ability->execute( array( 'days' => $days ) );
+
+		if ( is_wp_error( $result ) ) {
+			WP_CLI::error( $result->get_error_message() );
+		}
+
+		$format = $assoc_args['format'] ?? 'table';
+
+		if ( 'json' === $format || 'yaml' === $format ) {
+			Utils\format_items(
+				$format,
+				array( $result ),
+				array_keys( $result )
+			);
+			return;
+		}
+
+		$display = array(
+			array( 'Metric' => 'Total published artist profiles', 'Value' => (string) $result['total_artist_profiles'] ),
+			array( 'Metric' => 'Total published link pages', 'Value' => (string) $result['total_link_pages'] ),
+			array( 'Metric' => sprintf( 'Profiles created (last %d days)', $result['days'] ), 'Value' => (string) $result['profiles_created_recent'] ),
+			array( 'Metric' => sprintf( 'Active link pages (last %d days)', $result['days'] ), 'Value' => (string) $result['active_link_pages_recent'] ),
+		);
+		Utils\format_items( 'table', $display, array( 'Metric', 'Value' ) );
+	}
 }

--- a/inc/Commands/Artists/ArtistCommand.php
+++ b/inc/Commands/Artists/ArtistCommand.php
@@ -19,6 +19,61 @@ if ( ! defined( 'ABSPATH' ) ) {
 class ArtistCommand {
 
 	/**
+	 * Count published artist profiles.
+	 *
+	 * Thin wrapper over the extrachill/artists-list ability, which already
+	 * returns the published-profile total. No business logic lives here.
+	 *
+	 * ## OPTIONS
+	 *
+	 * [--format=<format>]
+	 * : Output format.
+	 * ---
+	 * default: count
+	 * options:
+	 *   - count
+	 *   - json
+	 * ---
+	 *
+	 * ## EXAMPLES
+	 *
+	 *     wp extrachill artists count
+	 *     wp extrachill artists count --format=json
+	 *
+	 * @subcommand count
+	 * @when after_wp_load
+	 */
+	public function count( $args, $assoc_args ) {
+		$ability = wp_get_ability( 'extrachill/artists-list' );
+		if ( ! $ability ) {
+			WP_CLI::error( 'extrachill/artists-list ability not available.' );
+		}
+
+		// Ask for a single row — we only need the `total`, not the page body.
+		$result = $ability->execute(
+			array(
+				'page'     => 1,
+				'per_page' => 1,
+			)
+		);
+
+		if ( is_wp_error( $result ) ) {
+			WP_CLI::error( $result->get_error_message() );
+		}
+
+		$total = isset( $result['total'] ) ? (int) $result['total'] : 0;
+
+		$format = $assoc_args['format'] ?? 'count';
+
+		if ( 'json' === $format ) {
+			WP_CLI::log( wp_json_encode( array( 'total' => $total ), JSON_PRETTY_PRINT ) );
+			return;
+		}
+
+		WP_CLI::log( (string) $total );
+	}
+
+	/**
 	 * Get artist profile data.
 	 *
 	 * ## OPTIONS

--- a/inc/Commands/Users/ArtistAccessCommand.php
+++ b/inc/Commands/Users/ArtistAccessCommand.php
@@ -69,6 +69,89 @@ class ArtistAccessCommand {
 	}
 
 	/**
+	 * Show artist access funnel stats.
+	 *
+	 * Thin wrapper over the extrachill/get-artist-access-stats ability:
+	 * windowed access-REQUEST count plus the current count of granted
+	 * artist/professional users. All logic lives in the ability.
+	 *
+	 * ## OPTIONS
+	 *
+	 * [--days=<days>]
+	 * : Window in days for the request count. 0 for all time.
+	 * ---
+	 * default: 28
+	 * ---
+	 *
+	 * [--format=<format>]
+	 * : Output format.
+	 * ---
+	 * default: table
+	 * options:
+	 *   - table
+	 *   - json
+	 * ---
+	 *
+	 * ## EXAMPLES
+	 *
+	 *     wp extrachill users access stats
+	 *     wp extrachill users access stats --days=90
+	 *     wp extrachill users access stats --format=json
+	 *
+	 * @when after_wp_load
+	 * @subcommand stats
+	 */
+	public function stats( $args, $assoc_args ) {
+		$ability = wp_get_ability( 'extrachill/get-artist-access-stats' );
+		if ( ! $ability ) {
+			WP_CLI::error( 'extrachill-users plugin is required (ability not found).' );
+		}
+
+		$days   = isset( $assoc_args['days'] ) ? (int) $assoc_args['days'] : 28;
+		$result = $ability->execute( array( 'days' => $days ) );
+
+		if ( is_wp_error( $result ) ) {
+			WP_CLI::error( $result->get_error_message() );
+		}
+
+		$format = $assoc_args['format'] ?? 'table';
+
+		if ( 'json' === $format ) {
+			WP_CLI::log( wp_json_encode( $result, JSON_PRETTY_PRINT ) );
+			return;
+		}
+
+		$rows = array(
+			array(
+				'Metric' => 'Period',
+				'Value'  => (string) ( $result['period'] ?? '' ),
+			),
+			array(
+				'Metric' => 'Requests in window',
+				'Value'  => (string) ( $result['requests_in_window'] ?? 0 ),
+			),
+			array(
+				'Metric' => 'Pending requests',
+				'Value'  => (string) ( $result['pending_requests'] ?? 0 ),
+			),
+			array(
+				'Metric' => 'Granted (artist)',
+				'Value'  => (string) ( $result['granted_artist'] ?? 0 ),
+			),
+			array(
+				'Metric' => 'Granted (professional)',
+				'Value'  => (string) ( $result['granted_professional'] ?? 0 ),
+			),
+			array(
+				'Metric' => 'Granted (total)',
+				'Value'  => (string) ( $result['granted_total'] ?? 0 ),
+			),
+		);
+
+		WP_CLI\Utils\format_items( 'table', $rows, array( 'Metric', 'Value' ) );
+	}
+
+	/**
 	 * Approve a pending artist access request.
 	 *
 	 * ## OPTIONS

--- a/inc/Commands/Users/TeamCommand.php
+++ b/inc/Commands/Users/TeamCommand.php
@@ -1,0 +1,107 @@
+<?php
+/**
+ * Team CLI Command
+ *
+ * Wraps the team-experience stats ability from extrachill-users.
+ *
+ * @package ExtraChill\CLI\Commands\Users
+ */
+
+namespace ExtraChill\CLI\Commands\Users;
+
+use WP_CLI;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Team-experience CLI command surface.
+ */
+class TeamCommand {
+
+	/**
+	 * Show team-experience cohort stats.
+	 *
+	 * Thin wrapper over the extrachill/get-team-experience-stats ability:
+	 * current extra_chill_team count, members added/removed in the window,
+	 * and the Studio/Roadie/submission event counts. All logic lives in the
+	 * ability (extrachill-users#127).
+	 *
+	 * ## OPTIONS
+	 *
+	 * [--days=<days>]
+	 * : Window in days for the event counts. 0 for all time.
+	 * ---
+	 * default: 28
+	 * ---
+	 *
+	 * [--format=<format>]
+	 * : Output format.
+	 * ---
+	 * default: table
+	 * options:
+	 *   - table
+	 *   - json
+	 * ---
+	 *
+	 * ## EXAMPLES
+	 *
+	 *     wp extrachill users team stats
+	 *     wp extrachill users team stats --days=90
+	 *     wp extrachill users team stats --format=json
+	 *
+	 * @when after_wp_load
+	 * @subcommand stats
+	 */
+	public function stats( $args, $assoc_args ) {
+		$ability = wp_get_ability( 'extrachill/get-team-experience-stats' );
+		if ( ! $ability ) {
+			WP_CLI::error( 'extrachill-users plugin is required (ability not found).' );
+		}
+
+		$days   = isset( $assoc_args['days'] ) ? (int) $assoc_args['days'] : 28;
+		$result = $ability->execute( array( 'days' => $days ) );
+
+		if ( is_wp_error( $result ) ) {
+			WP_CLI::error( $result->get_error_message() );
+		}
+
+		$format = $assoc_args['format'] ?? 'table';
+
+		if ( 'json' === $format ) {
+			WP_CLI::log( wp_json_encode( $result, JSON_PRETTY_PRINT ) );
+			return;
+		}
+
+		$events = isset( $result['events'] ) && is_array( $result['events'] ) ? $result['events'] : array();
+
+		$rows = array(
+			array(
+				'Metric' => 'Period',
+				'Value'  => (string) ( $result['period'] ?? '' ),
+			),
+			array(
+				'Metric' => 'Team members (current)',
+				'Value'  => (string) ( $result['team_member_count'] ?? 0 ),
+			),
+			array(
+				'Metric' => 'Members added (window)',
+				'Value'  => (string) ( $result['team_members_added'] ?? 0 ),
+			),
+			array(
+				'Metric' => 'Members removed (window)',
+				'Value'  => (string) ( $result['team_members_removed'] ?? 0 ),
+			),
+		);
+
+		foreach ( $events as $event_type => $count ) {
+			$rows[] = array(
+				'Metric' => (string) $event_type,
+				'Value'  => (string) (int) $count,
+			);
+		}
+
+		WP_CLI\Utils\format_items( 'table', $rows, array( 'Metric', 'Value' ) );
+	}
+}


### PR DESCRIPTION
## Summary

Implements the CLI measurability wins (#31) plus the team-cohort CLI surface for the team-experience instrumentation (Extra-Chill/extrachill-users#127). All commands are **thin wrappers** — logic lives in the wrapped abilities (canonical-home rule).

## Commands added

| Command | Wraps | Returns |
|---------|-------|---------|
| `wp extrachill artists count` | `extrachill/artists-list` | published-profile `total` |
| `wp extrachill users access stats --days=N` | `extrachill/get-artist-access-stats` (extrachill-users#128) | windowed request count + pending + granted artist/professional totals |
| `wp extrachill users team stats --days=N` | `extrachill/get-team-experience-stats` (extrachill-users#128) | team count + members added/removed + Studio/Roadie/submission event counts |

`extrachill users team` is registered as a new command class (`TeamCommand`) in the `CommandRegistry` map.

## Note on the existing commit on this branch

This branch already carried `feat: add wp extrachill artists stats` (from the artist-platform#72 funnel work — extrachill-cli is the canonical CLI home). That command coexists with the new `artists count` here; both are in `ArtistCommand`.

## Verification

- `php -l` clean on all changed files.
- `CommandRegistry` array alignment normalized with phpcbf after adding the new key. The PSR-4 class-file-naming and `## OPTIONS`-style param-doc findings are pre-existing house-style baseline across the whole CLI (the repo has no phpcs ruleset or CI lint gate) — the new `TeamCommand` matches the exact style of the sibling command classes.
- The wrapped read abilities were executed against live data and return correct values (team count 45, granted artist/professional 229/117).

Refs #31
Refs Extra-Chill/extrachill-users#127