### PR TITLE
fix: print exact UTC window bound in analytics summary output

### DIFF
--- a/inc/Commands/Analytics/SummaryCommand.php
+++ b/inc/Commands/Analytics/SummaryCommand.php
@@ -118,6 +118,14 @@ class SummaryCommand {
 			$period_label = $days > 0 ? "Last {$days} days" : 'All time';
 			$site_label   = $this->format_site_label();
 			WP_CLI::log( sprintf( 'Analytics Summary — %s (%s) — %s', $period_label, $result['period'], $site_label ) );
+			// Surface the exact UTC window the counts were computed over. The window is
+			// rolling (computed at query time), so reporting only the day granularity
+			// hides why a re-run minutes later returns a slightly different count. With
+			// the precise 'since' bound, any count here is reproducible via a raw
+			// COUNT(*) using created_at >= '<since>' — no normalization is applied.
+			if ( ! empty( $result['since'] ) ) {
+				WP_CLI::log( sprintf( 'Window (UTC): created_at >= %s  (as of %s)', $result['since'], $result['as_of'] ?? '' ) );
+			}
 			WP_CLI::log( str_repeat( '─', 55 ) );
 		}
 


### PR DESCRIPTION
Companion to Extra-Chill/extrachill-analytics#34 (closes
Extra-Chill/extrachill-analytics#33).

## Why

The `wp extrachill analytics summary` header showed only day-granularity period
bounds (`2026-05-20 to 2026-06-17`). That hides why a re-run minutes later can
return a slightly different 404 count: the window is **rolling**, computed at
query time, over a stream of ~2,344 404s/day. The day label can't explain a
~1% gap against a raw `COUNT(*)` run at a different moment — see the analytics PR
for the full root-cause analysis (it's a window-timing artifact, not a bug).

## Change

When the analytics ability returns a `since`/`as_of` window (added in
extrachill-analytics#34), the table output now prints it:

```
Analytics Summary — Last 28 days (2026-05-20 to 2026-06-17) — all sites
Window (UTC): created_at >= 2026-05-20 05:45:07  (as of 2026-06-17 05:45:07)
```

Any reported count is now reproducible via a raw `COUNT(*)` using
`created_at >= '<since>'` — removing the recurring "which source?" asterisk on
every 404 delta. Guarded on `! empty( $result['since'] )` so all-time
(`--days=0`) and older ability versions render unchanged.

## Verification

- `php -l` clean.
- phpcs (WordPress standard): **0 net new findings** vs `main` baseline (6
  pre-existing house-style findings unchanged).