### PR TITLE
feat: add wp extrachill analytics retention command

### DIFF
--- a/inc/CommandRegistry.php
+++ b/inc/CommandRegistry.php
@@ -32,43 +32,44 @@ class CommandRegistry {
 	public static function map() {
 		return array(
 			// Analytics commands.
-			'extrachill analytics summary' => Commands\Analytics\SummaryCommand::class,
-			'extrachill analytics 404'     => Commands\Analytics\FourOhFourCommand::class,
-			'extrachill analytics attacks' => Commands\Analytics\AttacksCommand::class,
-			'extrachill analytics errors'  => Commands\Analytics\ErrorsCommand::class,
+			'extrachill analytics summary'   => Commands\Analytics\SummaryCommand::class,
+			'extrachill analytics 404'       => Commands\Analytics\FourOhFourCommand::class,
+			'extrachill analytics attacks'   => Commands\Analytics\AttacksCommand::class,
+			'extrachill analytics errors'    => Commands\Analytics\ErrorsCommand::class,
+			'extrachill analytics retention' => Commands\Analytics\RetentionCommand::class,
 
 			// Events commands.
-			'extrachill events'            => Commands\Events\LocationCommand::class,
-			'extrachill venues'            => Commands\Events\VenueDiscoveryCommand::class,
-			'extrachill shows'             => Commands\Events\ConcertTrackingCommand::class,
+			'extrachill events'              => Commands\Events\LocationCommand::class,
+			'extrachill venues'              => Commands\Events\VenueDiscoveryCommand::class,
+			'extrachill shows'               => Commands\Events\ConcertTrackingCommand::class,
 
 			// SEO commands.
-			'extrachill seo redirects'     => Commands\SEO\RedirectsCommand::class,
+			'extrachill seo redirects'       => Commands\SEO\RedirectsCommand::class,
 
 			// Tools commands.
-			'extrachill tools qr'          => Commands\Tools\QRCodeCommand::class,
+			'extrachill tools qr'            => Commands\Tools\QRCodeCommand::class,
 
 			// Artists commands.
-			'extrachill artists'           => Commands\Artists\ArtistCommand::class,
+			'extrachill artists'             => Commands\Artists\ArtistCommand::class,
 
 			// Users commands.
-			'extrachill users'             => Commands\Users\BanCommand::class,
-			'extrachill users access'      => Commands\Users\ArtistAccessCommand::class,
-			'extrachill users team'        => Commands\Users\TeamCommand::class,
-			'extrachill users settings'    => Commands\Users\SettingsCommand::class,
-			'extrachill users profile'     => Commands\Users\ProfileCommand::class,
+			'extrachill users'               => Commands\Users\BanCommand::class,
+			'extrachill users access'        => Commands\Users\ArtistAccessCommand::class,
+			'extrachill users team'          => Commands\Users\TeamCommand::class,
+			'extrachill users settings'      => Commands\Users\SettingsCommand::class,
+			'extrachill users profile'       => Commands\Users\ProfileCommand::class,
 
 			// Community commands.
-			'extrachill community'         => Commands\Community\CommunityCommand::class,
+			'extrachill community'           => Commands\Community\CommunityCommand::class,
 
 			// Cache commands.
-			'extrachill cache'             => Commands\Cache\WarmCommand::class,
+			'extrachill cache'               => Commands\Cache\WarmCommand::class,
 
 			// Giveaway commands.
-			'extrachill giveaway'          => Commands\Giveaway\GiveawayCommand::class,
+			'extrachill giveaway'            => Commands\Giveaway\GiveawayCommand::class,
 
 			// Newsletter commands.
-			'extrachill newsletter'        => Commands\Newsletter\NewsletterCommand::class,
+			'extrachill newsletter'          => Commands\Newsletter\NewsletterCommand::class,
 		);
 	}
 }

--- a/inc/Commands/Analytics/RetentionCommand.php
+++ b/inc/Commands/Analytics/RetentionCommand.php
@@ -1,0 +1,175 @@
+<?php
+/**
+ * Analytics Retention CLI Command
+ *
+ * Surfaces deterministic, bot-filtered visitor-retention metrics from the
+ * extrachill-analytics plugin via the extrachill/get-retention-stats ability.
+ *
+ * @package ExtraChill\CLI\Commands\Analytics
+ */
+
+namespace ExtraChill\CLI\Commands\Analytics;
+
+use WP_CLI;
+use WP_CLI\Utils;
+use ExtraChill\CLI\Traits\NetworkAwareTrait;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+class RetentionCommand {
+
+	use NetworkAwareTrait;
+
+	/**
+	 * Show deterministic visitor-retention stats.
+	 *
+	 * Computes return rate, weekly cohort retention, cross-site return, and
+	 * session depth from the first-party pageview events (anonymous ec_vid
+	 * visitor_id). All metrics are bot-filtered by construction.
+	 *
+	 * ## OPTIONS
+	 *
+	 * [--days=<days>]
+	 * : Number of days to look back for the window.
+	 * ---
+	 * default: 28
+	 * ---
+	 *
+	 * [--cohort-weeks=<weeks>]
+	 * : Number of weekly cohorts for the retention curve.
+	 * ---
+	 * default: 8
+	 * ---
+	 *
+	 * [--site=<site>]
+	 * : Filter by site. Use a blog ID, 'all' for network-wide, or omit for current site.
+	 *
+	 * [--format=<format>]
+	 * : Output format.
+	 * ---
+	 * default: table
+	 * options:
+	 *   - table
+	 *   - json
+	 *   - csv
+	 * ---
+	 *
+	 * ## EXAMPLES
+	 *
+	 *     wp extrachill analytics retention
+	 *     wp extrachill analytics retention --days=90
+	 *     wp extrachill analytics retention --cohort-weeks=12 --format=json
+	 *     wp extrachill analytics retention --site=all
+	 *
+	 * @subcommand __default
+	 * @when after_wp_load
+	 */
+	public function __invoke( $args, $assoc_args ) {
+		$ability = wp_get_ability( 'extrachill/get-retention-stats' );
+
+		if ( ! $ability ) {
+			WP_CLI::error( 'extrachill/get-retention-stats ability not found. Is extrachill-analytics active?' );
+		}
+
+		$blog_id      = $this->get_site_filter( $assoc_args );
+		$days         = (int) ( $assoc_args['days'] ?? 28 );
+		$cohort_weeks = (int) ( $assoc_args['cohort-weeks'] ?? 8 );
+		$format       = $assoc_args['format'] ?? 'table';
+
+		$input = array(
+			'days'         => $days,
+			'cohort_weeks' => $cohort_weeks,
+		);
+
+		if ( $blog_id > 0 ) {
+			$input['blog_id'] = $blog_id;
+		}
+
+		$result = $ability->execute( $input );
+
+		if ( is_wp_error( $result ) ) {
+			WP_CLI::error( $result->get_error_message() );
+		}
+
+		if ( 'table' !== $format ) {
+			Utils\format_items(
+				$format,
+				$this->cohort_rows( $result ),
+				array( 'cohort_week', 'cohort_size', 'retention_w1', 'retention_w2' )
+			);
+			return;
+		}
+
+		$period_label = $days > 0 ? "Last {$days} days" : 'All time';
+		$site_label   = $this->format_site_label();
+		WP_CLI::log( sprintf( 'Visitor Retention — %s (%s) — %s', $period_label, $result['period'] ?? '', $site_label ) );
+		if ( ! empty( $result['since'] ) ) {
+			WP_CLI::log( sprintf( 'Window (UTC): created_at >= %s  (as of %s)', $result['since'], $result['as_of'] ?? '' ) );
+		}
+		WP_CLI::log( str_repeat( '─', 60 ) );
+
+		$rr = $result['return_rate'];
+		WP_CLI::log(
+			sprintf(
+				'Return rate:       %s%%  (%s of %s visitors active on >= 2 days)',
+				number_format( (float) $rr['rate'] * 100, 1 ),
+				number_format( (int) $rr['returning_visitors'] ),
+				number_format( (int) $rr['total_visitors'] )
+			)
+		);
+
+		$xs = $result['cross_site_return'];
+		WP_CLI::log(
+			sprintf(
+				'Cross-site return: %s%%  (%s of %s visitors hit >= 2 sites on >= 2 days)',
+				number_format( (float) $xs['rate'] * 100, 1 ),
+				number_format( (int) $xs['cross_site_visitors'] ),
+				number_format( (int) $xs['total_visitors'] )
+			)
+		);
+
+		$sd = $result['session_depth'];
+		WP_CLI::log(
+			sprintf(
+				'Session depth:     %s avg pageviews/visitor/day (max %s)',
+				$sd['avg_pageviews_per_visitor_day'],
+				number_format( (int) $sd['max_pageviews_per_visitor_day'] )
+			)
+		);
+
+		WP_CLI::log( '' );
+		WP_CLI::log( sprintf( 'Cohort retention (last %d weekly cohorts):', (int) $result['cohort_retention']['weeks'] ) );
+
+		$rows = $this->cohort_rows( $result );
+		if ( empty( $rows ) ) {
+			WP_CLI::log( '  (no cohorts in window)' );
+			return;
+		}
+
+		Utils\format_items( 'table', $rows, array( 'cohort_week', 'cohort_size', 'retention_w1', 'retention_w2' ) );
+	}
+
+	/**
+	 * Flatten the cohort retention list into displayable rows.
+	 *
+	 * @param array $result Ability result.
+	 * @return array<int, array<string, mixed>>
+	 */
+	private function cohort_rows( array $result ) {
+		$cohorts = isset( $result['cohort_retention']['cohorts'] ) ? $result['cohort_retention']['cohorts'] : array();
+		$rows    = array();
+
+		foreach ( $cohorts as $c ) {
+			$rows[] = array(
+				'cohort_week'  => $c['cohort_week'],
+				'cohort_size'  => number_format( (int) $c['cohort_size'] ),
+				'retention_w1' => number_format( (float) $c['retention_w1'] * 100, 1 ) . '%',
+				'retention_w2' => number_format( (float) $c['retention_w2'] * 100, 1 ) . '%',
+			);
+		}
+
+		return $rows;
+	}
+}


### PR DESCRIPTION
Refs Extra-Chill/extrachill-analytics#35
Pairs with Extra-Chill/extrachill-analytics#36

## Summary

Adds `wp extrachill analytics retention`, wrapping the new `extrachill/get-retention-stats` ability. Surfaces deterministic, bot-filtered visitor-retention metrics for operators/agents:

- **Return rate** — % of visitors active on ≥ 2 distinct UTC days.
- **Cohort retention** — per weekly first-seen cohort, % returning in week N+1 / N+2.
- **Cross-site return** — % of visitors who hit ≥ 2 distinct sites on ≥ 2 distinct days.
- **Session depth** — avg/max pageviews per visitor per day.

Options: `--days` (default 28), `--cohort-weeks` (default 8), `--site` (blog ID / `all` / current via `NetworkAwareTrait`), `--format` (table/json/csv).

## Architecture

- Registered in `CommandRegistry::map()` (single source of truth). The same map drives the AGENTS.md section generator, so the documented CLI surface auto-narrates the new command with **zero drift** — no manual `AgentsMdSection` edit needed. The command class uses the standard `@subcommand __default` + PHPDoc shortdesc the generator reflects over.
- Follows the existing `SummaryCommand` pattern exactly (same trait, same ability-wrapper shape, same output handling).

## Privacy

The command is a read-only wrapper over aggregate metrics; it surfaces no `visitor_id` values and no PII — only counts and ratios. (The privacy stance for the underlying cookie/events lives in extrachill-analytics#36.)

## Deploy ordering

The extrachill-analytics ability (#36) must deploy **before or with** this — the command guards on `wp_get_ability()` and errors cleanly if absent.

## Owner checklist

- [ ] **Privacy-policy disclosure line** must be published (page ID 3) before the feature is considered done — see extrachill-analytics#36 for the suggested sentence. Do not edit the live policy via the bot.

## Notes / verification

- `php -l` clean on both changed files.
- `phpcs --standard=WordPress` introduces zero new non-baseline findings; the remaining filename/class-doc findings are the house-style baseline shared by every command class in this repo (identical set to `SummaryCommand`).