### PR TITLE
feat: composed 'platform health' scorecard CLI command

### DIFF
--- a/inc/CommandRegistry.php
+++ b/inc/CommandRegistry.php
@@ -31,6 +31,9 @@ class CommandRegistry {
 	 */
 	public static function map() {
 		return array(
+			// Platform commands.
+			'extrachill platform'            => Commands\Platform\HealthCommand::class,
+
 			// Analytics commands.
 			'extrachill analytics summary'   => Commands\Analytics\SummaryCommand::class,
 			'extrachill analytics 404'       => Commands\Analytics\FourOhFourCommand::class,

--- a/inc/Commands/Platform/HealthCommand.php
+++ b/inc/Commands/Platform/HealthCommand.php
@@ -1,0 +1,515 @@
+<?php
+/**
+ * Platform Health CLI Command
+ *
+ * Composes a per-surface, bot-aware self-health scorecard for the Extra Chill
+ * network by CALLING existing abilities and stitching their output together.
+ * This is an AGGREGATION / PRESENTATION layer ONLY — it contains no business
+ * logic and runs no direct database queries. Every signal in the scorecard is
+ * produced by an ability that already owns that logic:
+ *
+ *   - Traffic (bot-aware)   datamachine/google-analytics  (traffic_sources)
+ *   - Return rate           extrachill/get-retention-stats
+ *   - Search-gap count      extrachill/get-search-gaps    (may be absent)
+ *   - Error rate            extrachill/get-php-error-summary
+ *   - Queue health          datamachine/get-jobs-summary
+ *   - Content inventory     wp_count_posts (core read, per registered type)
+ *
+ * Where an ability is not present on the install, the corresponding cell is
+ * rendered as an explicit "not instrumented" gap rather than faked or fataled.
+ * The visible gaps double as an instrumentation-coverage map.
+ *
+ * @package ExtraChill\CLI\Commands\Platform
+ */
+
+namespace ExtraChill\CLI\Commands\Platform;
+
+use WP_CLI;
+use WP_CLI\Utils;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Implements the `wp extrachill platform health` command.
+ */
+class HealthCommand {
+
+	/**
+	 * Sentinel rendered when an ability is not present on the install.
+	 *
+	 * @var string
+	 */
+	const GAP = 'not instrumented';
+
+	/**
+	 * Compose a per-surface, bot-aware platform-health scorecard.
+	 *
+	 * Walks every live network site and, for each, composes a scorecard row by
+	 * calling the abilities that already own each signal. No business logic is
+	 * implemented here — the command is a thin aggregator over abilities.
+	 *
+	 * Signals that depend on an absent ability are shown as an explicit
+	 * "not instrumented" gap, never faked and never fatal, so the scorecard
+	 * also reads as an instrumentation-coverage map.
+	 *
+	 * ## OPTIONS
+	 *
+	 * [--days=<days>]
+	 * : Look-back window (in days) for traffic, return rate, and error rate.
+	 * ---
+	 * default: 28
+	 * ---
+	 *
+	 * [--format=<format>]
+	 * : Output format. The "table" format prints a compact per-site block;
+	 *   "json" / "csv" emit one structured record per site.
+	 * ---
+	 * default: table
+	 * options:
+	 *   - table
+	 *   - json
+	 *   - csv
+	 * ---
+	 *
+	 * ## EXAMPLES
+	 *
+	 *     # Default 28-day scorecard for the whole network.
+	 *     wp extrachill platform health
+	 *
+	 *     # Last 7 days.
+	 *     wp extrachill platform health --days=7
+	 *
+	 *     # Machine-readable for piping into jq.
+	 *     wp extrachill platform health --format=json
+	 *
+	 * @subcommand health
+	 * @when after_wp_load
+	 *
+	 * @param array $args       Positional arguments (unused).
+	 * @param array $assoc_args Associative arguments (--days, --format).
+	 * @return void
+	 */
+	public function health( $args, $assoc_args ) {
+		$days   = max( 1, (int) ( $assoc_args['days'] ?? 28 ) );
+		$format = $assoc_args['format'] ?? 'table';
+
+		// Resolve which abilities are present once, up front. Absent abilities
+		// become visible gaps in every row rather than per-call failures.
+		$abilities = array(
+			'ga'         => function_exists( 'wp_get_ability' ) ? wp_get_ability( 'datamachine/google-analytics' ) : null,
+			'retention'  => function_exists( 'wp_get_ability' ) ? wp_get_ability( 'extrachill/get-retention-stats' ) : null,
+			'search_gap' => function_exists( 'wp_get_ability' ) ? wp_get_ability( 'extrachill/get-search-gaps' ) : null,
+			'errors'     => function_exists( 'wp_get_ability' ) ? wp_get_ability( 'extrachill/get-php-error-summary' ) : null,
+			'jobs'       => function_exists( 'wp_get_ability' ) ? wp_get_ability( 'datamachine/get-jobs-summary' ) : null,
+		);
+
+		// Network-global signals come from host-wide / network-scoped sources
+		// (a single debug.log, a single network-scoped jobs table). They are
+		// computed ONCE so the scorecard never implies false per-site
+		// granularity by repeating identical numbers on every row.
+		$network = array(
+			'errors_per_day' => $this->compose_errors( $abilities['errors'], $days ),
+			'queue_failed'   => $this->compose_queue( $abilities['jobs'], 'failed' ),
+			'queue_stuck'    => $this->compose_queue( $abilities['jobs'], 'stuck' ),
+		);
+
+		$records = array();
+		foreach ( $this->get_network_sites() as $blog_id => $hostname ) {
+			$records[] = $this->compose_site( $blog_id, $hostname, $days, $abilities );
+		}
+
+		if ( 'table' !== $format ) {
+			// In machine-readable output, attach the network-global signals to
+			// every record so each row is self-describing for piping/jq, while
+			// keeping their network-scoped meaning explicit via the key name.
+			$rows = array();
+			foreach ( $records as $r ) {
+				$rows[] = array_merge(
+					$r,
+					array(
+						'network_errors_per_day' => $network['errors_per_day'],
+						'network_queue_failed'   => $network['queue_failed'],
+						'network_queue_stuck'    => $network['queue_stuck'],
+					)
+				);
+			}
+			Utils\format_items(
+				$format,
+				$rows,
+				array( 'site', 'blog_id', 'sessions', 'organic_pct', 'direct_pct', 'return_rate', 'search_gaps', 'content', 'network_errors_per_day', 'network_queue_failed', 'network_queue_stuck' )
+			);
+			return;
+		}
+
+		$this->render_table( $records, $network, $days, $abilities );
+	}
+
+	/**
+	 * Compose a single site's scorecard record from ability output.
+	 *
+	 * @param int    $blog_id   Blog ID.
+	 * @param string $hostname  Site hostname (used as the GA hostName filter).
+	 * @param int    $days      Look-back window in days.
+	 * @param array  $abilities Resolved ability map (values may be null).
+	 * @return array<string, mixed>
+	 */
+	private function compose_site( $blog_id, $hostname, $days, array $abilities ) {
+		$traffic = $this->compose_traffic( $abilities['ga'], $hostname, $days );
+
+		return array(
+			'site'        => $hostname,
+			'blog_id'     => $blog_id,
+			'sessions'    => $traffic['sessions'],
+			'organic_pct' => $traffic['organic_pct'],
+			'direct_pct'  => $traffic['direct_pct'],
+			'return_rate' => $this->compose_return_rate( $abilities['retention'], $blog_id, $days ),
+			'search_gaps' => $this->compose_search_gaps( $abilities['search_gap'], $blog_id, $days ),
+			'content'     => $this->compose_content( $blog_id ),
+		);
+	}
+
+	/**
+	 * Compose bot-aware traffic totals from the GA traffic_sources action.
+	 *
+	 * @param object|null $ability  GA ability (or null if absent).
+	 * @param string      $hostname Site hostname for the hostName filter.
+	 * @param int         $days     Look-back window in days.
+	 * @return array{sessions:mixed, organic_pct:mixed, direct_pct:mixed}
+	 */
+	private function compose_traffic( $ability, $hostname, $days ) {
+		if ( ! $ability ) {
+			return array(
+				'sessions'    => self::GAP,
+				'organic_pct' => self::GAP,
+				'direct_pct'  => self::GAP,
+			);
+		}
+
+		$result = $ability->execute(
+			array(
+				'action'     => 'traffic_sources',
+				'hostname'   => $hostname,
+				'start_date' => $days . 'daysAgo',
+				'end_date'   => 'today',
+			)
+		);
+
+		if ( is_wp_error( $result ) || empty( $result['results'] ) ) {
+			return array(
+				'sessions'    => 0,
+				'organic_pct' => 0.0,
+				'direct_pct'  => 0.0,
+			);
+		}
+
+		$total   = 0;
+		$organic = 0;
+		$direct  = 0;
+		foreach ( $result['results'] as $row ) {
+			$sessions = (int) ( $row['sessions'] ?? 0 );
+			$total   += $sessions;
+
+			$medium = strtolower( (string) ( $row['sessionMedium'] ?? '' ) );
+			$source = strtolower( (string) ( $row['sessionSource'] ?? '' ) );
+
+			if ( 'organic' === $medium ) {
+				$organic += $sessions;
+			} elseif ( '(direct)' === $source || '(none)' === $medium ) {
+				$direct += $sessions;
+			}
+		}
+
+		return array(
+			'sessions'    => $total,
+			'organic_pct' => $total > 0 ? round( $organic / $total * 100, 1 ) : 0.0,
+			'direct_pct'  => $total > 0 ? round( $direct / $total * 100, 1 ) : 0.0,
+		);
+	}
+
+	/**
+	 * Compose the return-rate signal from extrachill/get-retention-stats.
+	 *
+	 * @param object|null $ability Retention ability (or null if absent).
+	 * @param int         $blog_id Blog ID.
+	 * @param int         $days    Look-back window in days.
+	 * @return mixed Percentage float, or the GAP sentinel.
+	 */
+	private function compose_return_rate( $ability, $blog_id, $days ) {
+		if ( ! $ability ) {
+			return self::GAP;
+		}
+
+		$result = $ability->execute(
+			array(
+				'days'    => $days,
+				'blog_id' => $blog_id,
+			)
+		);
+
+		if ( is_wp_error( $result ) || ! isset( $result['return_rate']['rate'] ) ) {
+			return 0.0;
+		}
+
+		return round( (float) $result['return_rate']['rate'] * 100, 1 );
+	}
+
+	/**
+	 * Compose the zero-result search-gap count from extrachill/get-search-gaps.
+	 *
+	 * This ability ships in a sibling PR (#39) and may not be present on the
+	 * install. When absent the cell is an explicit gap, never a hard failure.
+	 *
+	 * @param object|null $ability Search-gaps ability (or null if absent).
+	 * @param int         $blog_id Blog ID.
+	 * @param int         $days    Look-back window in days.
+	 * @return mixed Integer gap count, or the GAP sentinel.
+	 */
+	private function compose_search_gaps( $ability, $blog_id, $days ) {
+		if ( ! $ability ) {
+			return self::GAP;
+		}
+
+		$result = $ability->execute(
+			array(
+				'days'    => $days,
+				'blog_id' => $blog_id,
+			)
+		);
+
+		if ( is_wp_error( $result ) ) {
+			return 0;
+		}
+
+		// Be liberal about the shape the sibling ability returns: prefer an
+		// explicit total, fall back to counting a rows/gaps list.
+		if ( isset( $result['total'] ) ) {
+			return (int) $result['total'];
+		}
+		if ( isset( $result['count'] ) ) {
+			return (int) $result['count'];
+		}
+		foreach ( array( 'gaps', 'rows', 'results' ) as $key ) {
+			if ( isset( $result[ $key ] ) && is_array( $result[ $key ] ) ) {
+				return count( $result[ $key ] );
+			}
+		}
+
+		return 0;
+	}
+
+	/**
+	 * Compose the per-day user-facing error rate from get-php-error-summary.
+	 *
+	 * The error log is a single host-wide file, so this is a network-global
+	 * signal (computed once, not per-site).
+	 *
+	 * @param object|null $ability Error-summary ability (or null if absent).
+	 * @param int         $days    Look-back window in days.
+	 * @return mixed Per-day error rate float, or the GAP sentinel.
+	 */
+	private function compose_errors( $ability, $days ) {
+		if ( ! $ability ) {
+			return self::GAP;
+		}
+
+		$result = $ability->execute(
+			array(
+				'days'  => $days,
+				'limit' => 0,
+			)
+		);
+
+		if ( is_wp_error( $result ) ) {
+			return 0.0;
+		}
+
+		$total        = (int) ( $result['total'] ?? 0 );
+		$days_covered = max( 1, (int) ( $result['days_covered'] ?? $days ) );
+
+		return round( $total / $days_covered, 1 );
+	}
+
+	/**
+	 * Compose a queue-health metric from datamachine/get-jobs-summary.
+	 *
+	 * Data Machine jobs live in a single network-scoped table (under the base
+	 * prefix), so this is a network-global signal — independent of blog
+	 * context and computed once for the whole platform.
+	 *
+	 * @param object|null $ability Jobs-summary ability (or null if absent).
+	 * @param string      $metric  Either 'failed' or 'stuck'.
+	 * @return mixed Integer count, or the GAP sentinel.
+	 */
+	private function compose_queue( $ability, $metric ) {
+		if ( ! $ability ) {
+			return self::GAP;
+		}
+
+		$result = $ability->execute( array() );
+
+		if ( is_wp_error( $result ) || empty( $result['summary'] ) ) {
+			return 0;
+		}
+
+		$summary = $result['summary'];
+
+		if ( 'stuck' === $metric ) {
+			return (int) ( $summary['stuck_processing_count'] ?? 0 );
+		}
+
+		return (int) ( $summary['failed_count'] ?? 0 );
+	}
+
+	/**
+	 * Compose a content-inventory summary using core's wp_count_posts.
+	 *
+	 * Reads published counts for each public, non-built-in post type plus
+	 * core posts/pages. This is a core read, not business logic — there is no
+	 * Extra Chill ability that owns generic content counts.
+	 *
+	 * @param int $blog_id Blog ID.
+	 * @return string Compact "type:count" summary, e.g. "post:2820 page:12".
+	 */
+	private function compose_content( $blog_id ) {
+		$switched = false;
+		if ( get_current_blog_id() !== $blog_id && function_exists( 'switch_to_blog' ) ) {
+			switch_to_blog( $blog_id );
+			$switched = true;
+		}
+
+		$types = get_post_types( array( 'public' => true ), 'names' );
+
+		$parts = array();
+		foreach ( $types as $type ) {
+			if ( 'attachment' === $type ) {
+				continue;
+			}
+			$counts    = wp_count_posts( $type );
+			$published = isset( $counts->publish ) ? (int) $counts->publish : 0;
+			if ( $published > 0 ) {
+				$parts[] = $type . ':' . $published;
+			}
+		}
+
+		if ( $switched ) {
+			restore_current_blog();
+		}
+
+		return $parts ? implode( ' ', $parts ) : '(none)';
+	}
+
+	/**
+	 * Render the composed records as a skimmable per-site block report.
+	 *
+	 * @param array<int, array<string, mixed>> $records   Per-site composed records.
+	 * @param array<string, mixed>             $network   Network-global signals.
+	 * @param int                              $days      Look-back window in days.
+	 * @param array                            $abilities Resolved ability map.
+	 * @return void
+	 */
+	private function render_table( array $records, array $network, $days, array $abilities ) {
+		WP_CLI::log( sprintf( 'Platform Health Scorecard — last %d days — %s', $days, gmdate( 'Y-m-d H:i' ) . ' UTC' ) );
+		WP_CLI::log( str_repeat( '═', 72 ) );
+
+		// Surface which signals are instrumented up front (coverage map).
+		$coverage = array(
+			'Traffic (GA)' => (bool) $abilities['ga'],
+			'Return rate'  => (bool) $abilities['retention'],
+			'Search gaps'  => (bool) $abilities['search_gap'],
+			'Error rate'   => (bool) $abilities['errors'],
+			'Queue health' => (bool) $abilities['jobs'],
+		);
+		$present  = array();
+		$missing  = array();
+		foreach ( $coverage as $label => $ok ) {
+			if ( $ok ) {
+				$present[] = $label;
+			} else {
+				$missing[] = $label;
+			}
+		}
+		WP_CLI::log( 'Instrumented: ' . ( $present ? implode( ', ', $present ) : 'none' ) );
+		if ( $missing ) {
+			WP_CLI::log( 'GAPS:         ' . implode( ', ', $missing ) . '  (shown as "' . self::GAP . '")' );
+		}
+		WP_CLI::log( '' );
+
+		// Network-global signals (host-wide error log + network-scoped jobs
+		// table) are reported once, not faked into per-site granularity.
+		WP_CLI::log( 'Network-wide' );
+		WP_CLI::log( sprintf( '    Errors/day:  %s', $this->fmt( $network['errors_per_day'] ) ) );
+		WP_CLI::log( sprintf( '    Queue:       %s failed   %s stuck', $this->fmt( $network['queue_failed'] ), $this->fmt( $network['queue_stuck'] ) ) );
+		WP_CLI::log( '' );
+		WP_CLI::log( 'Per-surface' );
+		WP_CLI::log( str_repeat( '─', 72 ) );
+
+		foreach ( $records as $r ) {
+			WP_CLI::log( sprintf( '● %s  (blog %d)', $r['site'], $r['blog_id'] ) );
+			WP_CLI::log( sprintf( '    Traffic:     %s sessions   organic %s   direct %s', $this->fmt( $r['sessions'] ), $this->pct( $r['organic_pct'] ), $this->pct( $r['direct_pct'] ) ) );
+			WP_CLI::log( sprintf( '    Return rate: %s', $this->pct( $r['return_rate'] ) ) );
+			WP_CLI::log( sprintf( '    Search gaps: %s', $this->fmt( $r['search_gaps'] ) ) );
+			WP_CLI::log( sprintf( '    Content:     %s', $r['content'] ) );
+			WP_CLI::log( '' );
+		}
+
+		WP_CLI::log( str_repeat( '─', 72 ) );
+		WP_CLI::log( sprintf( '%d surfaces composed. Cells marked "%s" are coverage gaps, not zeroes.', count( $records ), self::GAP ) );
+	}
+
+	/**
+	 * Format a numeric value, passing the GAP sentinel through unchanged.
+	 *
+	 * @param mixed $value Value to format.
+	 * @return string
+	 */
+	private function fmt( $value ) {
+		if ( self::GAP === $value ) {
+			return self::GAP;
+		}
+		if ( is_float( $value ) ) {
+			return number_format( $value, 1 );
+		}
+		return number_format( (int) $value );
+	}
+
+	/**
+	 * Format a percentage value, passing the GAP sentinel through unchanged.
+	 *
+	 * @param mixed $value Value to format.
+	 * @return string
+	 */
+	private function pct( $value ) {
+		if ( self::GAP === $value ) {
+			return self::GAP;
+		}
+		return number_format( (float) $value, 1 ) . '%';
+	}
+
+	/**
+	 * Get all live (non-archived, non-deleted) network sites.
+	 *
+	 * @return array<int, string> Map of blog_id => hostname.
+	 */
+	private function get_network_sites() {
+		$sites = get_sites(
+			array(
+				'number'   => 100,
+				'archived' => 0,
+				'deleted'  => 0,
+				'fields'   => 'ids',
+			)
+		);
+
+		$map = array();
+		foreach ( $sites as $blog_id ) {
+			$details = get_blog_details( $blog_id );
+			if ( $details ) {
+				$map[ (int) $blog_id ] = rtrim( $details->domain, '/' );
+			}
+		}
+
+		return $map;
+	}
+}


### PR DESCRIPTION
## Summary

Adds `wp extrachill platform health [--days=28]` — a single composed read that emits a per-surface, bot-aware self-health scorecard for the whole network, replacing the ~15-probe manual sweep an operator/agent currently has to stitch by hand.

Closes #36.

## Abilities it composes (no logic of its own)

This command is an **aggregation/presentation layer ONLY**. It contains **no business logic** and runs **no direct DB queries** — it calls existing abilities via the WordPress Abilities API (`wp_get_ability()->execute()`) and composes their output, per the canonical-home rule (logic lives in abilities, not the CLI).

| Signal | Source ability (already owns the logic) |
|--------|------------------------------------------|
| Traffic (bot-aware: sessions, organic %, direct %) | `datamachine/google-analytics` (`traffic_sources` per hostname) |
| Return rate | `extrachill/get-retention-stats` |
| Search-gap count | `extrachill/get-search-gaps` (sibling #39 — **graceful if absent**) |
| Error rate (per day) | `extrachill/get-php-error-summary` |
| Queue health (failed / stuck) | `datamachine/get-jobs-summary` |
| Content inventory | core `wp_count_posts` per registered post type (a core read; no EC ability owns generic content counts) |

The only non-ability reads are core multisite/post-count primitives (`get_sites`, `wp_count_posts`) — no Extra Chill business logic is duplicated.

## Design notes

- **Gaps are visible, never faked.** When an ability isn't present on the install (e.g. `extrachill/get-search-gaps`, which ships in sibling #39), the cell renders as an explicit `not instrumented` gap and the command does **not** hard-fail. A coverage map is printed up front, so the scorecard doubles as an instrumentation-coverage report.
- **Network-global vs per-site honesty.** The PHP error log is a single host-wide file and Data Machine jobs live in one network-scoped table, so error rate and queue health are computed **once** and shown in a `Network-wide` block rather than repeated per-row as if they were per-site isolated. Per-site signals (traffic, return rate, search gaps, content) are shown per surface.
- **Self-narrating.** Registered through `CommandRegistry::map()`, the single source of truth that drives both WP-CLI registration and the AGENTS.md reflection generator, so the documented surface can't drift.
- `--format=table` prints a compact per-site block; `--format=json|csv` emit one structured record per site (with network-global signals attached under `network_*` keys for self-describing piping).

## Verification

- `php -l` clean on both changed files.
- `phpcs --standard=WordPress` clean except the repo-wide PSR-4 PascalCase filename baseline (`class-*.php`) that every existing command class in this plugin already carries — no new fixable findings introduced.
- Ran live on production (`wp extrachill platform health` at `--days=28` and `--days=7`, table + json): composes without fatal across all 9 live network sites, shows real GA/queue/error numbers where abilities exist, and `not instrumented` for the absent search-gaps ability.