### PR TITLE
fix: run artists CLI in artist platform site context

### DIFF
--- a/inc/Commands/Artists/ArtistCommand.php
+++ b/inc/Commands/Artists/ArtistCommand.php
@@ -19,6 +19,73 @@ if ( ! defined( 'ABSPATH' ) ) {
 class ArtistCommand {
 
 	/**
+	 * Switch into the artist platform site and ensure its abilities are loaded.
+	 *
+	 * The artist platform abilities (extrachill/artists-list,
+	 * extrachill/get-artist-platform-stats, etc.) are registered by the
+	 * extrachill-artist-platform plugin, which is only active on the artist
+	 * platform subsite. `wp extrachill artists ...` defaults to the network
+	 * main site where that plugin's code never loads, so the abilities are
+	 * absent from the registry and every subcommand fails with
+	 * "ability not available".
+	 *
+	 * switch_to_blog() alone does NOT fix this: it changes the active blog but
+	 * does not load an inactive plugin's PHP. This helper therefore switches to
+	 * the artist platform blog AND requires the plugin's abilities bootstrap,
+	 * then fires its (idempotent-guarded) category + ability registration so
+	 * the abilities resolve in this process.
+	 *
+	 * Each subcommand is a short-lived WP-CLI process, so the switch is left in
+	 * place for the remainder of the command (every subsequent ability execute()
+	 * must also run in the artist site context to read/write its data).
+	 *
+	 * @return void
+	 */
+	private function ensure_artist_site_context() {
+		if ( ! function_exists( 'ec_get_blog_id' ) ) {
+			WP_CLI::error( 'ec_get_blog_id() unavailable — extrachill-multisite must be active to resolve the artist platform site.' );
+		}
+
+		$blog_id = ec_get_blog_id( 'artist' );
+		if ( ! $blog_id ) {
+			WP_CLI::error( 'Could not resolve the artist platform site ID.' );
+		}
+
+		if ( get_current_blog_id() !== (int) $blog_id ) {
+			switch_to_blog( $blog_id );
+		}
+
+		// The artist platform plugin only loads on its own subsite, so its
+		// ability registration functions may not be defined here. Load the
+		// abilities bootstrap from the (now active) artist platform site.
+		if ( ! function_exists( 'extrachill_artist_platform_register_abilities' ) ) {
+			if ( ! defined( 'EXTRACHILL_ARTIST_PLATFORM_PLUGIN_DIR' ) ) {
+				define( 'EXTRACHILL_ARTIST_PLATFORM_PLUGIN_DIR', WP_PLUGIN_DIR . '/extrachill-artist-platform/' );
+			}
+
+			$abilities_bootstrap = EXTRACHILL_ARTIST_PLATFORM_PLUGIN_DIR . 'inc/abilities/abilities.php';
+			if ( ! is_readable( $abilities_bootstrap ) ) {
+				WP_CLI::error( 'Artist platform abilities bootstrap not found — is extrachill-artist-platform installed?' );
+			}
+
+			require_once $abilities_bootstrap;
+		}
+
+		// Fire registration directly (idempotent-guarded) rather than re-running
+		// the global wp_abilities_api_* actions, which would re-register every
+		// other plugin's abilities and trigger _doing_it_wrong notices.
+		if ( function_exists( 'extrachill_artist_platform_register_category' ) ) {
+			extrachill_artist_platform_register_category();
+		}
+		if ( function_exists( 'extrachill_artist_platform_register_abilities' )
+			&& function_exists( 'wp_has_ability' )
+			&& ! wp_has_ability( 'extrachill/get-artist-platform-stats' )
+		) {
+			extrachill_artist_platform_register_abilities();
+		}
+	}
+
+	/**
 	 * Count published artist profiles.
 	 *
 	 * Thin wrapper over the extrachill/artists-list ability, which already
@@ -44,6 +111,8 @@ class ArtistCommand {
 	 * @when after_wp_load
 	 */
 	public function count( $args, $assoc_args ) {
+		$this->ensure_artist_site_context();
+
 		$ability = wp_get_ability( 'extrachill/artists-list' );
 		if ( ! $ability ) {
 			WP_CLI::error( 'extrachill/artists-list ability not available.' );
@@ -100,6 +169,8 @@ class ArtistCommand {
 	 * @when after_wp_load
 	 */
 	public function get( $args, $assoc_args ) {
+		$this->ensure_artist_site_context();
+
 		$artist_id = absint( $args[0] );
 
 		$ability = wp_get_ability( 'extrachill/get-artist-data' );
@@ -166,6 +237,8 @@ class ArtistCommand {
 	 * @when after_wp_load
 	 */
 	public function create( $args, $assoc_args ) {
+		$this->ensure_artist_site_context();
+
 		$input = array( 'name' => $args[0] );
 
 		if ( isset( $assoc_args['bio'] ) ) {
@@ -244,6 +317,8 @@ class ArtistCommand {
 	 * @when after_wp_load
 	 */
 	public function update( $args, $assoc_args ) {
+		$this->ensure_artist_site_context();
+
 		$input = array( 'artist_id' => absint( $args[0] ) );
 
 		$field_map = array(
@@ -310,6 +385,8 @@ class ArtistCommand {
 	 * @when after_wp_load
 	 */
 	public function link_page( $args, $assoc_args ) {
+		$this->ensure_artist_site_context();
+
 		$artist_id = absint( $args[0] );
 
 		$ability = wp_get_ability( 'extrachill/get-link-page-data' );
@@ -360,6 +437,8 @@ class ArtistCommand {
 	 * @when after_wp_load
 	 */
 	public function save_socials( $args, $assoc_args ) {
+		$this->ensure_artist_site_context();
+
 		$artist_id    = absint( $args[0] );
 		$social_links = json_decode( $args[1], true );
 
@@ -411,6 +490,8 @@ class ArtistCommand {
 	 * @when after_wp_load
 	 */
 	public function save_links( $args, $assoc_args ) {
+		$this->ensure_artist_site_context();
+
 		$artist_id = absint( $args[0] );
 		$links     = json_decode( $args[1], true );
 
@@ -475,6 +556,8 @@ class ArtistCommand {
 	 * @when after_wp_load
 	 */
 	public function add_link( $args, $assoc_args ) {
+		$this->ensure_artist_site_context();
+
 		$artist_id = absint( $args[0] );
 		$url       = $args[1];
 		$text      = $args[2];
@@ -562,6 +645,8 @@ class ArtistCommand {
 	 * @when after_wp_load
 	 */
 	public function remove_link( $args, $assoc_args ) {
+		$this->ensure_artist_site_context();
+
 		$artist_id  = absint( $args[0] );
 		$identifier = $args[1];
 
@@ -646,6 +731,8 @@ class ArtistCommand {
 	 * @when after_wp_load
 	 */
 	public function move_link( $args, $assoc_args ) {
+		$this->ensure_artist_site_context();
+
 		$artist_id  = absint( $args[0] );
 		$identifier = $args[1];
 
@@ -782,6 +869,8 @@ class ArtistCommand {
 	 * @when after_wp_load
 	 */
 	public function save_styles( $args, $assoc_args ) {
+		$this->ensure_artist_site_context();
+
 		$artist_id = absint( $args[0] );
 
 		// --list mode: show current CSS vars.
@@ -889,6 +978,8 @@ class ArtistCommand {
 	 * @when after_wp_load
 	 */
 	public function save_settings( $args, $assoc_args ) {
+		$this->ensure_artist_site_context();
+
 		$artist_id = absint( $args[0] );
 
 		// --list mode.
@@ -989,6 +1080,8 @@ class ArtistCommand {
 	 * @when after_wp_load
 	 */
 	public function stats( $args, $assoc_args ) {
+		$this->ensure_artist_site_context();
+
 		$days = isset( $assoc_args['days'] ) ? max( 0, (int) $assoc_args['days'] ) : 28;
 
 		$ability = wp_get_ability( 'extrachill/get-artist-platform-stats' );


### PR DESCRIPTION
## Summary

Fixes `Extra-Chill/extrachill-artist-platform#75`. `wp extrachill artists stats` and `wp extrachill artists count` failed on prod with `Error: extrachill/get-artist-platform-stats ability not available` / `extrachill/artists-list ability not available`.

## Corrected diagnosis

The issue diagnosed this as a **registration bug in extrachill-artist-platform** (handler files required but abilities never registered). Investigation proved that diagnosis wrong:

- Both abilities **are** registered correctly in the plugin's `inc/abilities/registry.php` (lines 360 and 399, category `extrachill-artists`).
- They **do** appear at runtime — on `artist.extrachill.com` (blog 4): `wp_get_abilities()` lists both, and `wp extrachill artists stats --url=artist.extrachill.com` returns data.

The real bug is a **cross-site context bug in extrachill-cli**:

- `extrachill-artist-platform` is **only active on the artist platform subsite** (blog 4), not network-active.
- `wp extrachill artists ...` defaults to the network **main site** (blog 1), where the plugin's PHP never loads, so its `wp_abilities_api_init` callback never runs and the abilities are absent from the registry → "ability not available".
- `switch_to_blog()` **alone does not fix this** — it changes the active blog but does not load an inactive plugin's code (verified: the ability is still NOT FOUND after a bare `switch_to_blog`).

## Fix

Added a private `ensure_artist_site_context()` helper to `ArtistCommand` that:

1. Switches to the artist platform site via `ec_get_blog_id( 'artist' )` (idempotent — only if not already there).
2. Requires the plugin's abilities bootstrap (`inc/abilities/abilities.php`) when its registration functions aren't defined in the current process.
3. Fires the plugin's **idempotent-guarded** `extrachill_artist_platform_register_category()` + `extrachill_artist_platform_register_abilities()` directly — rather than re-firing the global `wp_abilities_api_*` actions, which would re-register every other plugin's abilities and trigger `_doing_it_wrong` notices.

Called at the top of all 13 `artists` subcommands. No changes to extrachill-artist-platform were needed.

## Verification (live, default main-site context)

| Command | Before | After |
|---|---|---|
| `wp extrachill artists stats` | `ability not available` | table: 98 profiles / 189 link pages |
| `wp extrachill artists count` | `ability not available` | `98` |
| `wp extrachill artists count --format=json` | error | `{ "total": 98 }` |
| `wp extrachill artists stats --days=90 --format=json` | error | full stats payload |
| `wp extrachill artists get <id>` | error | artist row |

Also confirmed idempotent when already on the artist subsite (`--url=artist.extrachill.com`) — no double-switch, no notices.

`php -l` clean on the changed file. (No phpcs config in this repo; CI runs the WordPress sniff.)

## Post-deploy expectation

`wp extrachill artists stats` / `count` (and all other `artists` subcommands) return data from any site context. The artist-platform abilities still register normally on blog 4 as before — unchanged.

Closes Extra-Chill/extrachill-artist-platform#75 (cross-repo; will not auto-close — close manually after merge).