### PR TITLE
feat: add --purge flag to users ban for hard-delete content

### DIFF
--- a/inc/Commands/Users/BanCommand.php
+++ b/inc/Commands/Users/BanCommand.php
@@ -43,10 +43,20 @@ class BanCommand {
 	 * [--note=<note>]
 	 * : Internal note.
 	 *
+	 * [--purge]
+	 * : PERMANENTLY hard-delete the user's content network-wide instead of
+	 * hiding it (posts, bbPress topics/replies, comments and owned/orphaned
+	 * attachments). Destructive and irreversible. Without this flag the default
+	 * behavior is preserved (content is hidden/drafted/spammed, never deleted).
+	 *
+	 * [--yes]
+	 * : Skip the interactive confirmation prompt for --purge.
+	 *
 	 * ## EXAMPLES
 	 *
 	 *     wp extrachill users ban 581 --reason-key=spam --reason="Link spam"
 	 *     wp extrachill users ban top-website-builder --reason-key=other --reason="Policy violation"
+	 *     wp extrachill users ban 581 --reason-key=spam --purge
 	 *
 	 * @when after_wp_load
 	 */
@@ -63,21 +73,40 @@ class BanCommand {
 
 		$reason_key = isset( $assoc_args['reason-key'] ) ? (string) $assoc_args['reason-key'] : 'spam';
 		$state      = isset( $assoc_args['state'] ) ? (string) $assoc_args['state'] : 'banned';
+		$purge      = ! empty( $assoc_args['purge'] );
+
+		if ( $purge ) {
+			WP_CLI::warning( sprintf( '--purge will PERMANENTLY delete all content owned by user %d (%s) network-wide. This cannot be undone.', (int) $user->ID, $user->user_login ) );
+			WP_CLI::confirm( 'Are you sure you want to permanently delete this user\'s content?', $assoc_args );
+		}
 
 		$result = $ability->execute(
 			array(
-				'user_id'    => (int) $user->ID,
-				'state'      => $state,
-				'reason_key' => $reason_key,
-				'reason'     => isset( $assoc_args['reason'] ) ? (string) $assoc_args['reason'] : '',
-				'note'       => isset( $assoc_args['note'] ) ? (string) $assoc_args['note'] : '',
-				'source'     => 'wp-cli',
-				'acted_by'   => 0,
+				'user_id'       => (int) $user->ID,
+				'state'         => $state,
+				'reason_key'    => $reason_key,
+				'reason'        => isset( $assoc_args['reason'] ) ? (string) $assoc_args['reason'] : '',
+				'note'          => isset( $assoc_args['note'] ) ? (string) $assoc_args['note'] : '',
+				'source'        => 'wp-cli',
+				'acted_by'      => 0,
+				'purge_content' => $purge,
 			)
 		);
 
 		if ( is_wp_error( $result ) ) {
 			WP_CLI::error( $result->get_error_message() );
+		}
+
+		if ( $purge && isset( $result['results']['purged'] ) && is_array( $result['results']['purged'] ) ) {
+			$purged = $result['results']['purged'];
+			WP_CLI::log(
+				sprintf(
+					'Purged content: %d post(s), %d comment(s), %d attachment(s).',
+					isset( $purged['posts'] ) ? (int) $purged['posts'] : 0,
+					isset( $purged['comments'] ) ? (int) $purged['comments'] : 0,
+					isset( $purged['attachments'] ) ? (int) $purged['attachments'] : 0
+				)
+			);
 		}
 
 		WP_CLI::success( sprintf( 'Applied %s moderation to user %d (%s).', $state, (int) $user->ID, $user->user_login ) );


### PR DESCRIPTION
## Summary
Adds a `--purge` flag to `wp extrachill users ban` that PERMANENTLY hard-deletes a moderated user's content network-wide instead of hiding it. This is the CLI half of Extra-Chill/extrachill-users#135 — the ability/content support lands in extrachill-users PR #140.

## What changed
- **`inc/Commands/Users/BanCommand.php`** — `ban` now accepts:
  - `--purge` — passes `purge_content => true` to the `extrachill/moderate-user` ability, triggering the new hard-delete path (posts, bbPress topics/replies, comments, and owned/orphaned attachments).
  - `--yes` — skips the interactive confirmation for `--purge`.
- When `--purge` is supplied, the command prints a destructive-action warning and requires confirmation (`WP_CLI::confirm`, skippable with `--yes`) before executing, then reports the purged counts (posts / comments / attachments).

## Safety / behavior
- **Opt-in only.** Without `--purge`, behavior is unchanged — content is hidden/drafted/spammed, never deleted.
- **Irreversible** — guarded by an explicit confirmation prompt and a warning.

## Dependency
Requires the `purge_content` input added in Extra-Chill/extrachill-users#140. Merge that first; this PR degrades gracefully (the ability simply ignores an unknown input) but the flag is only functional once the ability ships.

## Verification
- `php -l` clean.
- `phpcs --standard=WordPress` introduces zero new findings (only pre-existing house-style/docblock baseline on untouched code remains).

Refs Extra-Chill/extrachill-users#135