### PR TITLE
fix: stop analytics commands triggering the ambiguous --user warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,24 @@ The 404 analyzer categorizes URLs into 15 buckets:
 | `wp-includes-probe` | `/wp-includes/` probes | No — attack noise |
 | `author-enum` | `/?author=N` enumeration | No — attack noise |
 
+### Analytics — Reads (no acting user)
+
+The aggregate analytics reads are network/site queries that take **no acting-user
+context**:
+
+```bash
+wp extrachill analytics summary
+wp extrachill analytics search-gaps
+wp extrachill analytics retention
+wp extrachill analytics errors
+```
+
+Do **not** pass the global `--user` flag to these commands — it is unused. On
+installs where a `user_login` collides with a numeric user ID (e.g. a login of
+`"1"` alongside user ID `1`), passing `--user=1` makes WP-CLI print a harmless
+but noisy `Ambiguous user match detected` warning before the output, which
+clutters scripted captures. Omit `--user` entirely.
+
 ### Output Formats
 
 All list/query commands support `--format=table|json|csv`:

--- a/inc/Commands/Analytics/ErrorsCommand.php
+++ b/inc/Commands/Analytics/ErrorsCommand.php
@@ -88,6 +88,14 @@ class ErrorsCommand {
 	 *     # Force a snapshot of the current log tail, then report.
 	 *     wp extrachill analytics errors --snapshot
 	 *
+	 * ## NOTES
+	 *
+	 * This is a network/site read and takes NO acting-user context. Do not pass
+	 * the global `--user` flag — it is unused here and on installs where a
+	 * user_login collides with a numeric user ID (e.g. a login of "1" alongside
+	 * user ID 1) WP-CLI emits a harmless but noisy "Ambiguous user match
+	 * detected" warning before the output. Omit `--user` entirely.
+	 *
 	 * @subcommand __default
 	 * @when after_wp_load
 	 */

--- a/inc/Commands/Analytics/RetentionCommand.php
+++ b/inc/Commands/Analytics/RetentionCommand.php
@@ -63,6 +63,14 @@ class RetentionCommand {
 	 *     wp extrachill analytics retention --cohort-weeks=12 --format=json
 	 *     wp extrachill analytics retention --site=all
 	 *
+	 * ## NOTES
+	 *
+	 * This is a network/site read and takes NO acting-user context. Do not pass
+	 * the global `--user` flag — it is unused here and on installs where a
+	 * user_login collides with a numeric user ID (e.g. a login of "1" alongside
+	 * user ID 1) WP-CLI emits a harmless but noisy "Ambiguous user match
+	 * detected" warning before the output. Omit `--user` entirely.
+	 *
 	 * @subcommand __default
 	 * @when after_wp_load
 	 */

--- a/inc/Commands/Analytics/SearchGapsCommand.php
+++ b/inc/Commands/Analytics/SearchGapsCommand.php
@@ -84,6 +84,14 @@ class SearchGapsCommand {
 	 *     # JSON output for piping into jq / feeding content ops.
 	 *     wp extrachill analytics search-gaps --format=json
 	 *
+	 * ## NOTES
+	 *
+	 * This is a network/site read and takes NO acting-user context. Do not pass
+	 * the global `--user` flag — it is unused here and on installs where a
+	 * user_login collides with a numeric user ID (e.g. a login of "1" alongside
+	 * user ID 1) WP-CLI emits a harmless but noisy "Ambiguous user match
+	 * detected" warning before the output. Omit `--user` entirely.
+	 *
 	 * @subcommand __default
 	 * @when after_wp_load
 	 */

--- a/inc/Commands/Analytics/SummaryCommand.php
+++ b/inc/Commands/Analytics/SummaryCommand.php
@@ -60,6 +60,14 @@ class SummaryCommand {
 	 *     wp extrachill analytics summary --site=7
 	 *     wp extrachill analytics summary --format=json
 	 *
+	 * ## NOTES
+	 *
+	 * This is a network/site read and takes NO acting-user context. Do not pass
+	 * the global `--user` flag — it is unused here and on installs where a
+	 * user_login collides with a numeric user ID (e.g. a login of "1" alongside
+	 * user ID 1) WP-CLI emits a harmless but noisy "Ambiguous user match
+	 * detected" warning before the output. Omit `--user` entirely.
+	 *
 	 * @subcommand __default
 	 * @when after_wp_load
 	 */


### PR DESCRIPTION
## Summary

`wp extrachill analytics summary|search-gaps|retention|errors` emit a
`Warning: Ambiguous user match detected (both ID and user_login exist for
identifier '1')...` before output on every run when passed the global
`--user=1` flag. Harmless (the correct user/ID is used) but it fires on every
invocation, cluttering output and scripted captures. The Agent Ping flow and
documented data-collection commands pass `--user=1` to these reads.

## Determination — CASE A (commands take no acting user)

I read all four analytics command classes:

- `inc/Commands/Analytics/SummaryCommand.php`
- `inc/Commands/Analytics/RetentionCommand.php`
- `inc/Commands/Analytics/SearchGapsCommand.php`
- `inc/Commands/Analytics/ErrorsCommand.php`

**None of them reference `--user`, `assoc_args['user']`, current user, or
`wp_set_current_user`.** They are pure network/site reads that delegate to
`extrachill/get-analytics-summary`, `extrachill/get-retention-stats`,
`extrachill/get-search-gaps`, and `extrachill/get-php-error-summary`
respectively. (Repo-wide grep: the only `--user` consumers are `shows` and
`community` commands — not analytics.)

### Code proof of where the warning comes from

The warning is emitted entirely by WP-CLI **core**, not this plugin. WP-CLI's
`WP_CLI\Runner` registers an `init` (priority 0) hook during WP load that runs
**whenever the global `--user` flag is set**, calling `WP_CLI\Fetchers\User::get()`:

```php
// vendor/wp-cli/wp-cli/php/WP_CLI/Fetchers/User.php
if ( is_numeric( $arg ) ) {
    $check = get_user_by( 'login', $arg );
    $user  = get_user_by( 'id', $arg );
    if ( $check && $user ) {
        WP_CLI::warning( 'Ambiguous user match detected ...' );
    }
}
```

On this install user ID `1` is `chubes` **and** a separate user has
`user_login = "1"`, so `--user=1` matches both → warning. This `init` hook runs
before any `after_wp_load` command's `__invoke`, so a command cannot suppress it
from inside — the only fix is to **not pass the unnecessary `--user` flag**.

### Empirical verification

```
$ wp extrachill analytics summary --days=1            # documented/intended
(no ambiguous-user warning)

$ wp extrachill analytics summary --days=1 --user=1   # the unnecessary flag
Warning: Ambiguous user match detected (both ID and user_login exist for identifier '1')...
```

Command output is identical either way — confirming the flag is unnecessary and
dropping it removes the warning without changing behavior.

## The fix

Since these reads take no acting user, the fix is to make the intended
invocation authoritative and self-documenting rather than papering over a core
warning:

- Added a `## NOTES` block to each of the four analytics command docblocks
  (visible in `wp help extrachill analytics <cmd>`) stating the command takes no
  acting-user context and the global `--user` flag should be omitted, with a
  one-line explanation of the ambiguity warning.
- Added an "Analytics — Reads (no acting user)" section to `README.md` with the
  same guidance.

No command behavior changed; callers that legitimately need an acting user
(`shows`, `community`) are untouched.

## Note: Agent Ping prompt (out of scope, flagged not edited)

The `--user=1` that triggers this in practice is passed by the **Agent Ping flow
+ data-collection commands**, whose prompt lives in **flow config, not this
repo**. That prompt should drop `--user` from the analytics invocations. I did
**not** edit it here because it is not part of extrachill-cli — flagging it so it
can be cleaned up where it lives.

## Testing

- `php -l` clean on all four changed command files.
- Verified the warning fires with `--user=1` and does not fire without it
  (output identical), against the live install.

Closes #44