### PR TITLE
feat(events): show flow-fallback count in audit/fix-locations (#379)

### DIFF
--- a/inc/Commands/Events/LocationCommand.php
+++ b/inc/Commands/Events/LocationCommand.php
@@ -582,6 +582,12 @@ class LocationCommand {
 			WP_CLI::log( sprintf( 'Mismatches: %d', (int) $result['mismatch_count'] ) );
 			WP_CLI::log( sprintf( 'Fixed: %d', (int) $result['fixed_count'] ) );
 			WP_CLI::log( sprintf( 'Unresolved: %d', (int) $result['unresolved_count'] ) );
+			// flow_fallback = events sitting on the pipeline-center term because
+			// the venue city has no market mapping. Not a mismatch (can't be
+			// re-tagged), but a signal to add the city to the market map.
+			if ( isset( $result['flow_fallback_count'] ) ) {
+				WP_CLI::log( sprintf( 'Flow-fallback (needs market-map entry): %d', (int) $result['flow_fallback_count'] ) );
+			}
 		}
 	}
 


### PR DESCRIPTION
Refs #379

Companion to the extrachill-events change that adds a `flow_fallback` status +
`flow_fallback_count` to the reconcile-event-locations ability.

Displays the count in `wp extrachill events audit-locations` / `fix-locations`
table output:

    Flow-fallback (needs market-map entry): N

These are events sitting on the pipeline-center location term only because their
venue city has no market-map entry — not a mismatch (can't be re-tagged), but a
signal to extend the map. Guarded with `isset()` so the CLI stays compatible
with older ability versions.