### PR TITLE
feat(analytics): surface category coverage ratio in content-audit

### DIFF
--- a/inc/Commands/Analytics/ContentAuditCommand.php
+++ b/inc/Commands/Analytics/ContentAuditCommand.php
@@ -155,14 +155,25 @@ class ContentAuditCommand {
 				$window['end'] ?? ''
 			)
 		);
+		$published = (int) ( $result['published_total'] ?? 0 );
+		$traffic   = (int) ( $result['with_traffic'] ?? 0 );
 		WP_CLI::log(
 			sprintf(
 				'%d published · %d with traffic · %d comparable (>=%d sessions) · median dwell %ss',
-				(int) ( $result['published_total'] ?? 0 ),
-				(int) ( $result['with_traffic'] ?? 0 ),
+				$published,
+				$traffic,
 				(int) ( $result['comparable'] ?? 0 ),
 				$min_sessions,
 				$this->num( $result['median_duration'] ?? 0 )
+			)
+		);
+		$coverage = $published > 0 ? round( ( $traffic / $published ) * 100, 1 ) : 0.0;
+		WP_CLI::log(
+			sprintf(
+				'Coverage: %s%% (%d/%d) — a LOW ratio signals a DISCOVERY gap (fix: crosslink traffic IN), distinct from a content-quality gap.',
+				$this->num( $coverage ),
+				$traffic,
+				$published
 			)
 		);
 		WP_CLI::log( str_repeat( '─', 72 ) );


### PR DESCRIPTION
## What

Adds a first-class **coverage** line to the existing (shipped) `wp extrachill analytics content-audit` header, showing `with_traffic / published_total` as a percentage with a one-line note that a **LOW ratio signals a DISCOVERY gap** (the fix is crosslinking traffic IN), distinct from a content-quality gap.

```
Content Audit — category "interviews" — 28d window (2026-05-24 → 2026-06-20)
288 published · 103 with traffic · 11 comparable (>=5 sessions) · median dwell 32.9s
Coverage: 35.8% (103/288) — a LOW ratio signals a DISCOVERY gap (fix: crosslink traffic IN), distinct from a content-quality gap.
```

This surfaces the category-level signal called out in #42's validation comments: a category like **interviews (36%)** has a distribution problem, not a content problem, vs **song-meanings (99%)** where nearly everything already draws traffic. Advisory category context, not a per-post flag.

## Pure presentation change

The `datamachine/content-performance` ability already returns `published_total` and `with_traffic`, so **no ability change is needed** — this is entirely in `ContentAuditCommand`.

## Verified live (against the deployed ability)

- interviews → **35.8% (103/288)**
- song-meanings → **99.3% (286/288)**
- music-history → 87.7% (406/463)

Matches the spec's example figures. `php -l` clean; `phpcs --standard=WordPress` shows only the pre-existing house-style baseline (no new findings from this edit).