### PR TITLE
fix(health): read zero_result_total so platform health reports real search-gap counts

### DIFF
--- a/inc/Commands/Platform/HealthCommand.php
+++ b/inc/Commands/Platform/HealthCommand.php
@@ -282,8 +282,15 @@ class HealthCommand {
 			return 0;
 		}
 
-		// Be liberal about the shape the sibling ability returns: prefer an
-		// explicit total, fall back to counting a rows/gaps list.
+		// Be liberal about the shape the sibling ability returns: prefer the
+		// ability's explicit zero-result total, then other explicit totals,
+		// and finally fall back to counting a rows/gaps list.
+		if ( isset( $result['zero_result_total'] ) ) {
+			return (int) $result['zero_result_total'];
+		}
+		if ( isset( $result['zero_result'] ) ) {
+			return (int) $result['zero_result'];
+		}
 		if ( isset( $result['total'] ) ) {
 			return (int) $result['total'];
 		}


### PR DESCRIPTION
Fixes #43

## Root cause
`inc/Commands/Platform/HealthCommand.php::compose_search_gaps()` executes the `extrachill/get-search-gaps` ability and then probes the result for keys `total`, `count`, `gaps`, `rows`, `results` — **none of which the ability returns**. Every branch falls through to the final `return 0`.

The ability actually returns the zero-result count under the key `zero_result_total` (the sibling `inc/Commands/Analytics/SearchGapsCommand.php` correctly reads `$result['zero_result_total']`). This is a looks-true-but-isn't bug: the cell read a healthy-looking `0` that actually meant "accessor missed," not "no gaps."

## Before / after
- **Before:** `wp extrachill platform health` showed `Search gaps: 0` for all 9 surfaces, while `wp extrachill analytics search-gaps --days=28` reported ~9,083 real zero-result searches over the same window.
- **After:** the scorecard reads the real `zero_result_total`, so surfaces with zero-result searches report the true count (matching `analytics search-gaps`), and a surface with genuinely no zero-result searches still shows `0`.

## The fix (surgical)
In `compose_search_gaps()`, prefer the ability's explicit `zero_result_total` (then `zero_result`) before the existing `total`/`count`/`gaps`/`rows`/`results` probes, which are kept as defensive fallbacks. A few-line accessor change only.

- Does **not** touch the `extrachill/get-search-gaps` ability.
- Does **not** touch `SearchGapsCommand.php`.
- `php -l` clean.

## Note on per-surface scoping
As called out in #43, the ability does not appear to scope by `blog_id` today, so per-surface counts may all reflect the network-wide total. That is an independent gap in the `get-search-gaps` ability and out of scope for this surgical consumer fix — the headline "always reads 0" bug is fixed here.