### PR TITLE
fix(health): prefer active-window error rate in platform-health Errors/day

### DIFF
--- a/inc/Commands/Platform/HealthCommand.php
+++ b/inc/Commands/Platform/HealthCommand.php
@@ -332,6 +332,21 @@ class HealthCommand {
 			return 0.0;
 		}
 
+		// Prefer the active-window lens: it counts only signatures still
+		// firing inside the recent window, so resolved-but-persisted
+		// signatures (frozen fatals/warnings) no longer inflate the rate.
+		if ( isset( $result['active_per_day'] ) ) {
+			return round( (float) $result['active_per_day'], 1 );
+		}
+		if ( isset( $result['active_total'] ) ) {
+			$active_total       = (int) $result['active_total'];
+			$active_window_days = max( 1.0, (float) ( $result['active_window_hours'] ?? 24 ) / 24 );
+
+			return round( $active_total / $active_window_days, 1 );
+		}
+
+		// Fallback (older ability builds without the active-window lens):
+		// the blended persisted+live total over the look-back window.
 		$total        = (int) ( $result['total'] ?? 0 );
 		$days_covered = max( 1, (int) ( $result['days_covered'] ?? $days ) );
 


### PR DESCRIPTION
Fixes #64

## Root cause
The platform-health scorecard's **Errors/day** cell is composed in `HealthCommand::compose_errors()` (`inc/Commands/Platform/HealthCommand.php`). It executed `extrachill/get-php-error-summary` and derived the per-day rate from the **blended persisted+live total**:

```php
$total        = (int) ( $result['total'] ?? 0 );
$days_covered = max( 1, (int) ( $result['days_covered'] ?? $days ) );
return round( $total / $days_covered, 1 );
```

That blended `total` includes resolved-but-persisted signatures — dead/frozen entries that no longer fire (the cookie fatal + two `theme.json` warnings, all frozen since 06-20). The ability **already returns** an active-window lens (shipped by extrachill-analytics#55): `active_total`, `active_per_day`, `active_window_hours`. The consumer simply wasn't reading it.

## Fix
`compose_errors()` now **prefers the active-window lens**, surgically (same file/shape as the already-merged #63):

1. If `active_per_day` is present → return it directly (already a per-day rate, no division).
2. Else if `active_total` is present → `active_total / max(1, active_window_hours/24)`.
3. Else → fall back to the existing blended `total / days_covered` path (older ability builds without the lens).

## Before / after
On prod right now the ability returns `total=81,895`, `active_total=5,689`, `active_per_day=812.7`, `active_window_hours=24`:

- **Before:** ~8,502 errors/day (10x inflated by resolved-but-persisted signatures)
- **After:** ~813 errors/day (active lens — what is actually firing)

## Scope / safety
- The `extrachill/get-php-error-summary` ability is **untouched** — it already returns the right fields.
- Fallbacks preserve behavior on older ability builds that don't emit the active-window keys.
- `php -l` clean. No local phpcs in the worktree; edit follows the file's existing array-arrow alignment.