### PR TITLE
fix: clear phpstan lint findings in HealthCommand + CrosslinkTargetsCommand

### DIFF
--- a/inc/Commands/Analytics/CrosslinkTargetsCommand.php
+++ b/inc/Commands/Analytics/CrosslinkTargetsCommand.php
@@ -145,7 +145,7 @@ class CrosslinkTargetsCommand {
 			return;
 		}
 
-		$period_label = $days > 0 ? "Last {$days} days" : 'All time';
+		$period_label = "Last {$days} days";
 		WP_CLI::log( sprintf( 'Crosslink Targets — %s (%s)', $period_label, $result['period'] ?? '' ) );
 
 		$graph = (array) ( $result['link_graph'] ?? array() );

--- a/inc/Commands/Platform/HealthCommand.php
+++ b/inc/Commands/Platform/HealthCommand.php
@@ -173,7 +173,7 @@ class HealthCommand {
 	/**
 	 * Compose bot-aware traffic totals from the GA traffic_sources action.
 	 *
-	 * @param object|null $ability  GA ability (or null if absent).
+	 * @param \WP_Ability|null $ability  GA ability (or null if absent).
 	 * @param string      $hostname Site hostname for the hostName filter.
 	 * @param int         $days     Look-back window in days.
 	 * @return array{sessions:mixed, organic_pct:mixed, direct_pct:mixed}
@@ -231,7 +231,7 @@ class HealthCommand {
 	/**
 	 * Compose the return-rate signal from extrachill/get-retention-stats.
 	 *
-	 * @param object|null $ability Retention ability (or null if absent).
+	 * @param \WP_Ability|null $ability Retention ability (or null if absent).
 	 * @param int         $blog_id Blog ID.
 	 * @param int         $days    Look-back window in days.
 	 * @return mixed Percentage float, or the GAP sentinel.
@@ -261,7 +261,7 @@ class HealthCommand {
 	 * This ability ships in a sibling PR (#39) and may not be present on the
 	 * install. When absent the cell is an explicit gap, never a hard failure.
 	 *
-	 * @param object|null $ability Search-gaps ability (or null if absent).
+	 * @param \WP_Ability|null $ability Search-gaps ability (or null if absent).
 	 * @param int         $blog_id Blog ID.
 	 * @param int         $days    Look-back window in days.
 	 * @return mixed Integer gap count, or the GAP sentinel.
@@ -312,7 +312,7 @@ class HealthCommand {
 	 * The error log is a single host-wide file, so this is a network-global
 	 * signal (computed once, not per-site).
 	 *
-	 * @param object|null $ability Error-summary ability (or null if absent).
+	 * @param \WP_Ability|null $ability Error-summary ability (or null if absent).
 	 * @param int         $days    Look-back window in days.
 	 * @return mixed Per-day error rate float, or the GAP sentinel.
 	 */
@@ -360,7 +360,7 @@ class HealthCommand {
 	 * prefix), so this is a network-global signal — independent of blog
 	 * context and computed once for the whole platform.
 	 *
-	 * @param object|null $ability Jobs-summary ability (or null if absent).
+	 * @param \WP_Ability|null $ability Jobs-summary ability (or null if absent).
 	 * @param string      $metric  Either 'failed' or 'stuck'.
 	 * @return mixed Integer count, or the GAP sentinel.
 	 */


### PR DESCRIPTION
## Summary
Post-merge lint fix-forward. The release lint gate surfaced 6 PHPSTAN level-7 findings on the files #63/#65/#67 touched. All fixed; `homeboy lint` now passes with no findings.

## Changes
- `HealthCommand.php` — 5 pre-existing `Call to undefined method object::execute()` findings (from the original #38 scorecard command, surfaced because #63/#65 touched the file): the `compose_*` ability params were `@param object|null`; `wp_get_ability()` returns `?WP_Ability`, so the docblocks are now `@param \WP_Ability|null` and PHPSTAN resolves `execute()`.
- `CrosslinkTargetsCommand.php:148` — `$days > 0` was always-true (`$days = max(1, ...)`), so the `'All time'` branch was dead; simplified to the "Last N days" label.

No behavior change — pure type-doc + dead-branch cleanup.

## Verify
`php -l` clean; `homeboy lint extrachill-cli --changed-since v0.22.0` → "lint phase passed with no findings".