### PR TITLE
fix(analytics): render demand-drill decliner/riser rows in table format

### DIFF
--- a/inc/Commands/Analytics/DemandDrillCommand.php
+++ b/inc/Commands/Analytics/DemandDrillCommand.php
@@ -250,7 +250,14 @@ class DemandDrillCommand {
 	}
 
 	/**
-	 * Print a set of contributor rows as a table, or an empty marker.
+	 * Print a set of contributor rows as an aligned table, or an empty marker.
+	 *
+	 * Rendered through WP_CLI::log() rather than Utils\format_items() so the rows
+	 * share the logger's output stream with the section headers. Utils\format_items()
+	 * echoes the table directly to STDOUT, which flushes out of order relative to
+	 * the WP_CLI::log() header lines — dumping every table at the end of the
+	 * command, detached from its "Top decliners/risers" header and leaving the
+	 * headers looking blank (#69).
 	 *
 	 * @param array $rows Contributor rows from the ability.
 	 * @return void
@@ -261,11 +268,54 @@ class DemandDrillCommand {
 			return;
 		}
 
-		Utils\format_items(
-			'table',
-			array_map( array( $this, 'display_row' ), $rows ),
-			array( 'target', 'net_click_change', 'clicks_prior', 'clicks_current', 'position_prior', 'position_current', 'position_change' )
-		);
+		$columns = array( 'target', 'net_click_change', 'clicks_prior', 'clicks_current', 'position_prior', 'position_current', 'position_change' );
+		$display = array_map( array( $this, 'display_row' ), $rows );
+
+		$header = array_combine( $columns, $columns );
+
+		$widths = array();
+		foreach ( $columns as $column ) {
+			$widths[ $column ] = $this->cell_width( $column );
+		}
+		foreach ( $display as $row ) {
+			foreach ( $columns as $column ) {
+				$widths[ $column ] = max( $widths[ $column ], $this->cell_width( (string) $row[ $column ] ) );
+			}
+		}
+
+		WP_CLI::log( '    ' . $this->table_line( $header, $columns, $widths ) );
+		foreach ( $display as $row ) {
+			WP_CLI::log( '    ' . $this->table_line( $row, $columns, $widths ) );
+		}
+	}
+
+	/**
+	 * Build one space-padded, column-aligned table line.
+	 *
+	 * @param array<string,mixed> $row     Row keyed by column.
+	 * @param array<int,string>   $columns Ordered column keys.
+	 * @param array<string,int>   $widths  Column display-width map.
+	 * @return string
+	 */
+	private function table_line( array $row, array $columns, array $widths ) {
+		$cells = array();
+		foreach ( $columns as $column ) {
+			$value   = (string) $row[ $column ];
+			$padding = max( 0, $widths[ $column ] - $this->cell_width( $value ) );
+			$cells[] = $value . str_repeat( ' ', $padding );
+		}
+
+		return rtrim( implode( '  ', $cells ) );
+	}
+
+	/**
+	 * Display width of a cell value, counting multibyte glyphs (e.g. em-dash) as one.
+	 *
+	 * @param string $value Cell value.
+	 * @return int
+	 */
+	private function cell_width( $value ) {
+		return function_exists( 'mb_strwidth' ) ? mb_strwidth( $value, 'UTF-8' ) : strlen( $value );
 	}
 
 	/**


### PR DESCRIPTION
Fixes #69

## Root cause
The table-format branch was not "dropping" rows at all — it was emitting them on the **wrong output stream**, so they flushed out of order and detached from their headers.

`print_rows()` rendered each contributor table via `WP_CLI\Utils\format_items( 'table', ... )`, which writes the table **directly to STDOUT** (`WP_CLI\Formatter` → `echo`). Every header and summary line, by contrast, goes through `WP_CLI::log()`, which routes through WP-CLI's buffered `Logger`. The two streams flush in different order, so all four tables (page decliners/risers, query decliners/risers) got dumped at the **very end** of the command — after the closing legend — leaving each "Top decliners/risers:" header looking blank.

`--format=json` was unaffected because it goes through a single `Utils\format_items()` call with no interleaved logger output, which is why every row was present in JSON but invisible in the default table view.

## Fix
Render the contributor rows through `WP_CLI::log()` so they share the logger's output stream with their headers and stay in order. Rows are formatted as a hand-aligned, space-padded table (`table_line()` + a multibyte-aware `cell_width()` so the em-dash placeholder counts as one glyph and columns line up). The ability (`extrachill/get-demand-drill`) is untouched — it always returned correct data; this is purely the CLI table renderer.

The json/csv path still uses `Utils\format_items()` (correct — those formats are a single call with no interleaved logger output).

## Before
```
  Top decliners (lost the most clicks):

  Top risers (gained the most clicks):
...
position_change > 0 means ...
target	net_click_change	clicks_prior	...
https://events.extrachill.com/events/wrestle-rave	-18	18	0	...
(all four tables dumped here, at the bottom, detached from their headers)
```

## After
```
  Top decliners (lost the most clicks):
    target                                             net_click_change  clicks_prior  clicks_current  position_prior  position_current  position_change
    https://events.extrachill.com/events/wrestle-rave  -18               18            0               4.5             —                 —
    ...

  Top risers (gained the most clicks):
    target                                                       net_click_change  ...
    https://events.extrachill.com/events/austin-noise-fest-...   +77               ...
```

## Verification
- `php -l` clean.
- phpcs `--standard=WordPress` (incl. `--warning-severity=1`): zero findings on the changed methods. The only findings on the file are pre-existing repo-baseline PSR-4 filename / class-docblock errors on unchanged lines (1, 33, 35), not touched by this PR.
- Exercised the renderer against live GSC ability data (`--surface=events --weeks=4`): decliner/riser rows now print directly under their headers, correctly aligned, matching what `--format=json` returns.