### PR TITLE
docs(analytics): cross-reference the growth and demand-drill demand bases in CLI longdescs/output

### DIFF
--- a/inc/Commands/Analytics/DemandDrillCommand.php
+++ b/inc/Commands/Analytics/DemandDrillCommand.php
@@ -42,6 +42,12 @@ class DemandDrillCommand {
 	 * its current and prior average position so a rank-loss is obvious. Turns a
 	 * declining surface slope from a number into a page-level action list.
 	 *
+	 * BASIS: GSC CLICKS (~2-3 day lagged), net of two equal windows. This is a
+	 * different lens from `wp extrachill analytics growth`, whose demand figure is
+	 * a GA4 organic-SESSIONS weekly slope — the two can legitimately disagree in
+	 * sign without either being wrong. A sign mismatch is not a regression. For
+	 * the GA organic-sessions slope, run `wp extrachill analytics growth`.
+	 *
 	 * ## OPTIONS
 	 *
 	 * [--surface=<surface>]
@@ -247,6 +253,9 @@ class DemandDrillCommand {
 		WP_CLI::log( '' );
 		WP_CLI::log( 'position_change > 0 means the average position WORSENED (dropped lower on the SERP). A decliner that' );
 		WP_CLI::log( 'lost rank → rank-recovery / gsc-opportunities lever; one that held rank but lost clicks → content/crosslink lever.' );
+		WP_CLI::log( '' );
+		WP_CLI::log( 'Basis here is GSC CLICKS (~2-3 day lagged), net of two windows. The `wp extrachill analytics growth` demand' );
+		WP_CLI::log( 'figure is a GA4 organic-SESSIONS weekly slope — a different lens; a sign mismatch between the two is not a regression.' );
 	}
 
 	/**

--- a/inc/Commands/Analytics/GrowthCommand.php
+++ b/inc/Commands/Analytics/GrowthCommand.php
@@ -37,6 +37,11 @@ class GrowthCommand {
 	 * produce) is highlighted. Unmeasurable dimensions show as "not instrumented"
 	 * coverage gaps, never as zeros.
 	 *
+	 * DEMAND BASIS: the demand slope here is GA4 organic SESSIONS (weekly-trend
+	 * regression). For per-page/per-query GSC CLICK attribution — a different lens
+	 * that can legitimately disagree in sign — see `wp extrachill analytics
+	 * demand-drill`. A sign mismatch between the two is not a regression.
+	 *
 	 * ## OPTIONS
 	 *
 	 * [--weeks=<weeks>]
@@ -134,6 +139,10 @@ class GrowthCommand {
 				WP_CLI::log( sprintf( '  %s [%s]: %s', $gap['surface'], $gap['dimension'], $gap['reason'] ) );
 			}
 		}
+
+		WP_CLI::log( '' );
+		WP_CLI::log( 'demand_slope_pct = GA4 organic-SESSIONS weekly slope. For per-page/per-query GSC CLICK attribution' );
+		WP_CLI::log( '(a different lens that can legitimately disagree in sign), run `wp extrachill analytics demand-drill`.' );
 	}
 
 	/**


### PR DESCRIPTION
## Summary

Mirror of the cross-reference docs fix landed in extrachill-analytics (analytics#73 / Extra-Chill/extrachill-analytics#74) at the CLI layer, so the two "events demand" commands stop reading as a contradiction.

Two commands answer "events demand" with **opposite signs** off different bases:

- **`wp extrachill analytics growth`** (demand portion) → events demand slope **−29.65%/wk**. Basis: **GA4 organic SESSIONS**, weekly-trend regression.
- **`wp extrachill analytics demand-drill --surface=events`** → net click change **+1,878**. Basis: **GSC CLICKS** (~2-3 day lagged), net of two equal windows.

Different metric, math, and window — they can legitimately disagree in sign without either being wrong. Nothing in either command's longdesc or output said so, so an operator reading both flags a false regression (it happened this session).

## Changes (docs/strings-only)

- `GrowthCommand.php`: longdesc now names the demand basis (GA4 organic-sessions weekly slope) and points at `demand-drill` for the GSC click lens; added a two-line output footer with the same cross-reference and the "a sign mismatch is not a regression" caveat.
- `DemandDrillCommand.php`: longdesc now names the basis (GSC clicks, ~2-3 day lagged, net of two windows) and points at `growth` for the GA slope; added a two-line output footer with the same caveat.

## Scope

- Longdesc + `WP_CLI::log` output strings only. No flags, math, windows, or logic changed.

## Verify

- `php -l` clean on both files.
- `phpcs --standard=WordPress` on both files: **0 NEW findings** vs the committed baseline (6 on GrowthCommand, 5 on DemandDrillCommand — identical before and after; all are the pre-existing PSR-4 `class-<name>.php` / Yoda baseline that exists across the repo, none on the changed lines).

Companion to Extra-Chill/extrachill-analytics#74 (Fixes Extra-Chill/extrachill-analytics#73).