### PR TITLE
fix(autoloader): guard against class redeclare when two plugin copies coexist

### DIFF
--- a/inc/Autoloader.php
+++ b/inc/Autoloader.php
@@ -49,6 +49,19 @@ class Autoloader {
 					return;
 				}
 
+				// Bail if the class is already declared. `require_once` only
+				// dedupes by resolved file path, so when a second copy of this
+				// plugin is loaded from a different directory (e.g. a Data
+				// Machine Code worktree under the workspace alongside the live
+				// plugin), each copy registers its own autoload closure rooted
+				// at its own `inc/`. Without this guard the second closure
+				// requires its copy of an already-declared class and triggers a
+				// fatal "Cannot redeclare class" error. The class check keys on
+				// the class name, not the path, so the first declaration wins.
+				if ( class_exists( $class_name, false ) || interface_exists( $class_name, false ) || trait_exists( $class_name, false ) ) {
+					return;
+				}
+
 				$relative = substr( $class_name, $len );
 				$file     = $inc . str_replace( '\\', '/', $relative ) . '.php';
 


### PR DESCRIPTION
## Summary

Fixes a **live PHP fatal** that fired on the network:

```
PHP Fatal error: Cannot redeclare class ExtraChill\CLI\Commands\Analytics\DemandDrillCommand
(previously declared in /var/www/.../wp-content/plugins/extrachill-cli/inc/Commands/Analytics/DemandDrillCommand.php:33)
in /var/lib/datamachine/workspace/extrachill-cli@fix-demand-drill-table/inc/Commands/Analytics/DemandDrillCommand.php on line 33
```

- First/last seen: 2026-06-22 01:22:40 UTC (single isolated CLI-context event, signature `bf40da1b4129`).
- The trace shows the **live network-active plugin** copy declared the class first, then a **Data Machine Code worktree** copy of the *same* file was loaded second in the same PHP process → redeclare fatal.

## Root cause

The PSR-4 autoloader closure in `inc/Autoloader.php` used `require_once`, which **only dedupes by resolved file path**. When two copies of the plugin are present in one PHP process — the live `wp-content/plugins/extrachill-cli` copy plus a worktree copy under `/var/lib/datamachine/workspace/extrachill-cli@<branch>` (e.g. when a `wp` command runs in a context where the worktree's `extrachill-cli.php` also bootstraps) — each copy registers its own autoload closure rooted at its own `inc/`. The second closure `require_once`'s its own copy of a class the first copy already declared. Because the paths differ, `require_once` does not dedupe → `Cannot redeclare class`.

## Fix

Guard the autoload closure with `class_exists()/interface_exists()/trait_exists($name, false)` **before** requiring the file. The check keys on the class name (not the path), so the first declaration always wins and a coexisting second plugin copy can never redeclare an already-loaded class.

This is minimal, defense-in-depth, and lives in the single funnel all `ExtraChill\CLI\*` class loading passes through. It does not change behavior for the normal single-copy case.

## Verification

- `php -l inc/Autoloader.php` → no syntax errors.
- Standalone two-copy repro (two closures rooted at distinct `inc/` dirs both resolving the same FQN) confirms the guarded closure loads the class once with no redeclare fatal.

## Notes

The presence of two coexisting plugin copies in one process is itself a workspace/runtime concern (a worktree copy being loaded alongside the live plugin), but the autoloader should never fatal because of it — that is what this PR hardens. If the coexistence path warrants its own follow-up at the workspace/runtime layer, it can be tracked separately.