### PR TITLE
fix(analytics): yoda condition in GrowthCommand to clear release lint gate

### DIFF
--- a/inc/Commands/Analytics/GrowthCommand.php
+++ b/inc/Commands/Analytics/GrowthCommand.php
@@ -240,7 +240,7 @@ class GrowthCommand {
 		$float = (float) $value;
 
 		// Render whole numbers without a trailing ".0"; otherwise round to 2dp.
-		if ( $float === floor( $float ) ) {
+		if ( floor( $float ) === $float ) {
 			return (string) (int) $float;
 		}
 


### PR DESCRIPTION
One-line Yoda-condition fix at GrowthCommand.php:243 (`floor($float) === $float`). Pre-existing line surfaced by the #71 doc PR touching the file; blocks the release lint gate. No behavior change.