### PR TITLE
fix: label crosslink-targets CLI orphan count as zero-inbound

### DIFF
--- a/inc/Commands/Analytics/CrosslinkTargetsCommand.php
+++ b/inc/Commands/Analytics/CrosslinkTargetsCommand.php
@@ -29,11 +29,13 @@ class CrosslinkTargetsCommand {
 	 *
 	 * JOINs the conversion-map per-article ranking with the Data Machine link
 	 * graph: blog-1 editorial articles that returning visitors re-enter AND that
-	 * are orphaned / low-inbound, each tagged with category, inbound count, and a
-	 * suggested forward surface (events/community) to route a new internal link
-	 * toward. This is a DRY-RUN list — it inserts no links; it is the targeting
-	 * pass the crosslink hook consumes. An empty or short list IS the finding
-	 * (no returning article journeys in window, or the catalog is already
+	 * are orphaned / low-inbound (orphan = zero INBOUND links, i.e. nothing links
+	 * TO the post — NOT the zero-OUTBOUND "posts_without_links" count from
+	 * `wp datamachine links diagnose`), each tagged with category, inbound count,
+	 * and a suggested forward surface (events/community) to route a new internal
+	 * link toward. This is a DRY-RUN list — it inserts no links; it is the
+	 * targeting pass the crosslink hook consumes. An empty or short list IS the
+	 * finding (no returning article journeys in window, or the catalog is already
 	 * well-linked), not a bug.
 	 *
 	 * ## OPTIONS
@@ -149,12 +151,18 @@ class CrosslinkTargetsCommand {
 		WP_CLI::log( sprintf( 'Crosslink Targets — %s (%s)', $period_label, $result['period'] ?? '' ) );
 
 		$graph = (array) ( $result['link_graph'] ?? array() );
+		// "orphaned" here = zero-INBOUND (nothing links TO the post), per the link
+		// graph. This is NOT the zero-OUTBOUND "posts_without_links" figure from
+		// `wp datamachine links diagnose` — the two count opposite edges of the
+		// link graph and are not comparable. Label it explicitly so the two
+		// numbers are never conflated as movement.
+		$inbound_orphans = (int) ( $graph['inbound_orphan_count'] ?? $graph['orphan_count'] ?? 0 );
 		WP_CLI::log(
 			sprintf(
-				'Link graph: %s — %s posts scanned, %s orphaned.',
+				'Link graph: %s — %s posts scanned, %s zero-inbound orphans (nothing links to them; NOT the zero-outbound count from `wp datamachine links diagnose`).',
 				! empty( $graph['available'] ) ? 'available' : 'UNAVAILABLE',
 				number_format( (int) ( $graph['total_scanned'] ?? 0 ) ),
-				number_format( (int) ( $graph['orphan_count'] ?? 0 ) )
+				number_format( $inbound_orphans )
 			)
 		);
 		WP_CLI::log(


### PR DESCRIPTION
## The bug (CLI half of an ambiguous-label fix)

The `wp extrachill analytics crosslink-targets` command printed the link-graph orphan figure as a bare `%s orphaned`. That count is **zero-INBOUND** (nothing links *to* the post), but `wp datamachine links diagnose` reports **zero-OUTBOUND** `posts_without_links` (the post links to nothing) under a similarly generic label. The two measure **opposite edges** of the link graph and are not comparable — yet seeing "2,399 orphaned" here next to "2,818 orphaned" from `links diagnose` reads as movement when it is a definition difference.

## What this is — and isn't

- **Labeling only — no logic change.** The number is unchanged.

## What I changed

- The CLI link-graph summary line now reads "**zero-inbound orphans (nothing links to them; NOT the zero-outbound count from `wp datamachine links diagnose`)**" instead of a bare "orphaned".
- It now reads the new self-documenting **`inbound_orphan_count`** from the ability payload, falling back to the deprecated `orphan_count`.
- The command docblock spells out that orphan here = zero inbound, distinct from `links diagnose`'s zero-outbound count.

This mirrors the canonical labeling fix in the `get-crosslink-targets` ability (extrachill-analytics PR #105). The CLI is a thin wrapper; the ability owns the logic — this PR only fixes the wrapper's echoed label.

## Confirmation of scope

- No orphan scan duplicated; no link-graph primitive touched.
- `php -l` clean.