### PR TITLE
fix: repoint QR command ownership to network

### DIFF
--- a/homeboy.json
+++ b/homeboy.json
@@ -6,6 +6,11 @@
   },
   "id": "extrachill-cli",
   "remote_path": "wp-content/plugins/extrachill-cli",
+  "self_checks": {
+    "test": [
+      "php tests/QRCodeCommandTest.php"
+    ]
+  },
   "version_targets": [
     {
       "file": "extrachill-cli.php",

--- a/inc/Commands/Tools/QRCodeCommand.php
+++ b/inc/Commands/Tools/QRCodeCommand.php
@@ -2,9 +2,9 @@
 /**
  * QR Code CLI Commands
  *
- * Delegates to the existing `extrachill/generate-qr-code` ability provided by
- * extrachill-admin-tools. This keeps QR generation primitive logic in its
- * existing home while exposing a CLI entrypoint under `wp extrachill`.
+ * Delegates to the canonical `extrachill/generate-qr-code` ability provided by
+ * Extra Chill Network. This keeps QR generation primitive logic in its owning
+ * plugin while exposing a CLI entrypoint under `wp extrachill`.
  *
  * @package ExtraChill\CLI\Commands\Tools
  */
@@ -98,7 +98,7 @@ class QRCodeCommand {
 	 */
 	private function ensure_qr_ability() {
 		if ( ! wp_get_ability( 'extrachill/generate-qr-code' ) ) {
-			WP_CLI::error( 'QR code ability is unavailable. Ensure extrachill-admin-tools is active and abilities are registered.' );
+			WP_CLI::error( 'QR code ability is unavailable. Ensure Extra Chill Network is active and abilities are registered.' );
 		}
 	}
 }

--- a/tests/QRCodeCommandTest.php
+++ b/tests/QRCodeCommandTest.php
@@ -1,0 +1,127 @@
+<?php
+/**
+ * Focused behavior tests for the QR code CLI command.
+ */
+
+define( 'ABSPATH', __DIR__ . '/' );
+
+class QRCodeCommandTestError extends RuntimeException {}
+
+class WP_CLI {
+	public static $messages = array();
+
+	public static function error( $message ) {
+		throw new QRCodeCommandTestError( $message );
+	}
+
+	public static function success( $message ) {
+		self::$messages[] = 'Success: ' . $message;
+	}
+
+	public static function log( $message ) {
+		self::$messages[] = $message;
+	}
+}
+
+class QRCodeCommandTestAbility {
+	public $inputs = array();
+
+	public function execute( $input ) {
+		$this->inputs[] = $input;
+
+		return array(
+			'image'     => base64_encode( 'png-bytes' ),
+			'mime_type' => 'image/png',
+			'url'       => $input['url'],
+			'size'      => 1000,
+		);
+	}
+}
+
+class QRCodeCommandTestFilesystem {
+	public function put_contents( $path, $contents ) {
+		return file_put_contents( $path, $contents );
+	}
+}
+
+$qr_code_test_ability = null;
+
+function wp_get_ability( $name ) {
+	global $qr_code_test_ability;
+
+	if ( 'extrachill/generate-qr-code' !== $name ) {
+		throw new RuntimeException( 'Unexpected ability requested: ' . $name );
+	}
+
+	return $qr_code_test_ability;
+}
+
+function wp_parse_url( $url ) {
+	return parse_url( $url );
+}
+
+function is_wp_error( $value ) {
+	return false;
+}
+
+function qr_code_test_assert_same( $expected, $actual, $message ) {
+	if ( $expected !== $actual ) {
+		throw new RuntimeException(
+			$message . '\nExpected: ' . var_export( $expected, true ) . '\nActual: ' . var_export( $actual, true )
+		);
+	}
+}
+
+require_once dirname( __DIR__ ) . '/inc/Commands/Tools/QRCodeCommand.php';
+
+use ExtraChill\CLI\Commands\Tools\QRCodeCommand;
+
+$output = tempnam( sys_get_temp_dir(), 'extrachill-qr-test-' );
+if ( false === $output ) {
+	throw new RuntimeException( 'Failed to allocate test output file.' );
+}
+
+try {
+	global $wp_filesystem, $qr_code_test_ability;
+
+	$wp_filesystem        = new QRCodeCommandTestFilesystem();
+	$qr_code_test_ability = new QRCodeCommandTestAbility();
+	WP_CLI::$messages     = array();
+
+	$command = new QRCodeCommand();
+	$command->generate(
+		array( 'https://example.com/path' ),
+		array( 'output' => $output )
+	);
+
+	qr_code_test_assert_same(
+		array( array( 'url' => 'https://example.com/path' ) ),
+		$qr_code_test_ability->inputs,
+		'Command must invoke the canonical QR ability with the existing input contract.'
+	);
+	qr_code_test_assert_same( 'png-bytes', file_get_contents( $output ), 'Command must decode and write the returned PNG bytes.' );
+	qr_code_test_assert_same(
+		array(
+			'Success: QR code generated: ' . $output . ' (9 bytes)',
+			'URL: https://example.com/path',
+		),
+		WP_CLI::$messages,
+		'Command success output must remain compatible.'
+	);
+
+	$qr_code_test_ability = null;
+	try {
+		$command->generate( array( 'https://example.com' ), array( 'output' => $output ) );
+		throw new RuntimeException( 'Missing QR ability did not terminate the command.' );
+	} catch ( QRCodeCommandTestError $error ) {
+		qr_code_test_assert_same(
+			'QR code ability is unavailable. Ensure Extra Chill Network is active and abilities are registered.',
+			$error->getMessage(),
+			'Missing ability error must identify the canonical owner.'
+		);
+	}
+} finally {
+	@unlink( $output );
+}
+
+fwrite( STDOUT, "QRCodeCommand tests passed.\n" );


### PR DESCRIPTION
## Summary
- identify Extra Chill Network as the owner of the canonical `extrachill/generate-qr-code` ability
- preserve the QR command's ability input, decoded PNG file-writing, success output, and error exit behavior
- add focused command coverage for canonical ability invocation, output compatibility, and missing-owner guidance

Closes #82.
Related: Extra-Chill/extrachill-network#103.
Epic: Extra-Chill/extrachill-admin-tools#16.

## Compatibility
The command continues to resolve and execute `extrachill/generate-qr-code` with `{ url }` and consumes the preserved base64 `image` field. No QR implementation or owner-specific API is added to CLI, so the existing Admin Tools registration and the replacement Network registration are both compatible during the staged migration.

## Landing Order
Extra-Chill/extrachill-network#103 should land before Admin Tools removes its ability registration. This CLI PR may land before or after the Network PR because the canonical ability name and response shape remain unchanged; it only updates ownership documentation and missing-dependency guidance.

## Tests
- `php tests/QRCodeCommandTest.php` (passes)
- `php -l inc/Commands/Tools/QRCodeCommand.php` (passes)
- `php -l tests/QRCodeCommandTest.php` (passes)
- `homeboy review extrachill-cli lint --path /var/lib/datamachine/workspace/extrachill-cli@retire-admin-tools-qr-owner --changed-only` (passes with no findings; Homeboy reports a local PHPStan PHAR bootstrap warning but exits successfully)
- full lint attempted; blocked by 63 pre-existing repository findings outside this diff
- Homeboy PHPUnit gate attempted; runner failed before tests because the local WP Codebox recipe-builder module is unavailable