### PR TITLE
fix: pass explicit fputcsv escape argument

### DIFF
--- a/inc/Commands/Analytics/RevenueCommand.php
+++ b/inc/Commands/Analytics/RevenueCommand.php
@@ -242,7 +242,7 @@ class RevenueCommand {
 			return new \WP_Error( 'mediavine_tmp_open', 'Could not open the temp CSV for writing.' );
 		}
 
-		fputcsv( $handle, $headers );
+		fputcsv( $handle, $headers, ',', '"', '\\' );
 
 		foreach ( $rows as $row ) {
 			fputcsv(
@@ -256,7 +256,10 @@ class RevenueCommand {
 					$row['viewability'] ?? 0,
 					$row['fillRate'] ?? 0,
 					$row['impressionsPerPageview'] ?? 0,
-				)
+				),
+				',',
+				'"',
+				'\\'
 			);
 		}
 


### PR DESCRIPTION
Fixes #86.

Preserves PHP's current backslash escape behavior explicitly for both temporary CSV writes, removing PHP 8.4 deprecation floods without changing output semantics.

Verification:
- `php -l inc/Commands/Analytics/RevenueCommand.php`
- `git diff --check`