### PR TITLE
fix: align crosslink targets with inbound contract

### DIFF
--- a/homeboy.json
+++ b/homeboy.json
@@ -8,7 +8,8 @@
   "remote_path": "wp-content/plugins/extrachill-cli",
   "self_checks": {
     "test": [
-      "php tests/QRCodeCommandTest.php"
+      "php tests/QRCodeCommandTest.php",
+      "php tests/CrosslinkTargetsCommandTest.php"
     ]
   },
   "version_targets": [

--- a/inc/Commands/Analytics/CrosslinkTargetsCommand.php
+++ b/inc/Commands/Analytics/CrosslinkTargetsCommand.php
@@ -7,8 +7,8 @@
  * get-conversion-map per-article journey ranking with the Data Machine internal
  * link graph to produce a ranked, dry-run crosslink ops-pass targeting list:
  * blog-1 articles that returning visitors re-enter AND that are orphaned /
- * low-inbound, tagged with category and a suggested forward surface
- * (events/community). This command only shapes that result for the terminal.
+ * low-inbound. Each result is a target page that needs contextual inbound links
+ * TO it. This command only shapes that result for the terminal.
  *
  * @package ExtraChill\CLI\Commands\Analytics
  */
@@ -31,12 +31,11 @@ class CrosslinkTargetsCommand {
 	 * graph: blog-1 editorial articles that returning visitors re-enter AND that
 	 * are orphaned / low-inbound (orphan = zero INBOUND links, i.e. nothing links
 	 * TO the post — NOT the zero-OUTBOUND "posts_without_links" count from
-	 * `wp datamachine links diagnose`), each tagged with category, inbound count,
-	 * and a suggested forward surface (events/community) to route a new internal
-	 * link toward. This is a DRY-RUN list — it inserts no links; it is the
-	 * targeting pass the crosslink hook consumes. An empty or short list IS the
-	 * finding (no returning article journeys in window, or the catalog is already
-	 * well-linked), not a bug.
+	 * `wp datamachine links diagnose`). Each result is a target page that needs
+	 * contextual inbound links TO it. This is a DRY-RUN list — it inserts no
+	 * links; it is the targeting pass the crosslink hook consumes. An empty or
+	 * short list IS the finding (no returning article journeys in window, or the
+	 * catalog is already well-linked), not a bug.
 	 *
 	 * ## OPTIONS
 	 *
@@ -142,7 +141,7 @@ class CrosslinkTargetsCommand {
 
 		if ( 'table' !== $format ) {
 			$rows    = array_map( array( $this, 'target_row' ), $targets );
-			$columns = array( 'post_id', 'title', 'category', 'returned', 'inbound_links', 'orphan', 'suggested_surface', 'score' );
+			$columns = array( 'post_id', 'title', 'category', 'returned', 'inbound_links', 'orphan', 'score' );
 			Utils\format_items( $format, $rows, $columns );
 			return;
 		}
@@ -189,7 +188,7 @@ class CrosslinkTargetsCommand {
 		Utils\format_items(
 			'table',
 			$rows,
-			array( 'post_id', 'title', 'category', 'returned', 'inbound_links', 'orphan', 'suggested_surface', 'score' )
+			array( 'post_id', 'title', 'category', 'returned', 'inbound_links', 'orphan', 'score' )
 		);
 
 		if ( ! empty( $result['note'] ) ) {
@@ -206,14 +205,13 @@ class CrosslinkTargetsCommand {
 	 */
 	private function target_row( $t ) {
 		return array(
-			'post_id'           => (int) ( $t['post_id'] ?? 0 ),
-			'title'             => $this->truncate( (string) ( $t['title'] ?? '(unknown)' ), 50 ),
-			'category'          => $this->truncate( (string) ( $t['category'] ?? '' ), 22 ),
-			'returned'          => number_format( (int) ( $t['returned'] ?? 0 ) ),
-			'inbound_links'     => (int) ( $t['inbound_links'] ?? 0 ),
-			'orphan'            => ! empty( $t['orphan'] ) ? 'yes' : 'no',
-			'suggested_surface' => (string) ( $t['suggested_surface'] ?? '' ),
-			'score'             => $t['score'] ?? 0,
+			'post_id'       => (int) ( $t['post_id'] ?? 0 ),
+			'title'         => $this->truncate( (string) ( $t['title'] ?? '(unknown)' ), 50 ),
+			'category'      => $this->truncate( (string) ( $t['category'] ?? '' ), 22 ),
+			'returned'      => number_format( (int) ( $t['returned'] ?? 0 ) ),
+			'inbound_links' => (int) ( $t['inbound_links'] ?? 0 ),
+			'orphan'        => ! empty( $t['orphan'] ) ? 'yes' : 'no',
+			'score'         => $t['score'] ?? 0,
 		);
 	}
 

--- a/tests/CrosslinkTargetsCommandTest.php
+++ b/tests/CrosslinkTargetsCommandTest.php
@@ -1,0 +1,105 @@
+<?php
+/**
+ * Focused presenter tests for the crosslink targets CLI command.
+ */
+
+namespace {
+	define( 'ABSPATH', __DIR__ . '/' );
+
+	class WP_CLI {
+		public static $messages = array();
+
+		public static function error( $message ) {
+			throw new RuntimeException( $message );
+		}
+
+		public static function log( $message ) {
+			self::$messages[] = $message;
+		}
+	}
+
+	class CrosslinkTargetsCommandTestAbility {
+		public function execute( $input ) {
+			return array(
+				'period'     => '2026-06-14 to 2026-07-12',
+				'scanned'    => 1,
+				'link_graph' => array(
+					'available'            => true,
+					'total_scanned'        => 100,
+					'inbound_orphan_count' => 4,
+				),
+				'targets'    => array(
+					array(
+						'post_id'           => 88,
+						'title'             => 'Target article',
+						'category'          => 'Music News',
+						'returned'          => 12,
+						'inbound_links'     => 0,
+						'orphan'            => true,
+						'suggested_surface' => 'community',
+						'score'             => 42,
+					),
+				),
+			);
+		}
+	}
+
+	$crosslink_targets_test_ability = new CrosslinkTargetsCommandTestAbility();
+
+	function wp_get_ability( $name ) {
+		global $crosslink_targets_test_ability;
+
+		if ( 'extrachill/get-crosslink-targets' !== $name ) {
+			throw new RuntimeException( 'Unexpected ability requested: ' . $name );
+		}
+
+		return $crosslink_targets_test_ability;
+	}
+
+	function is_wp_error( $value ) {
+		return false;
+	}
+
+	function crosslink_targets_test_assert_same( $expected, $actual, $message ) {
+		if ( $expected !== $actual ) {
+			throw new RuntimeException(
+				$message . '\nExpected: ' . var_export( $expected, true ) . '\nActual: ' . var_export( $actual, true )
+			);
+		}
+	}
+}
+
+namespace WP_CLI\Utils {
+	$crosslink_targets_test_formats = array();
+
+	function format_items( $format, $items, $fields ) {
+		global $crosslink_targets_test_formats;
+
+		$crosslink_targets_test_formats[] = compact( 'format', 'items', 'fields' );
+	}
+}
+
+namespace {
+	require_once dirname( __DIR__ ) . '/inc/Commands/Analytics/CrosslinkTargetsCommand.php';
+
+	use ExtraChill\CLI\Commands\Analytics\CrosslinkTargetsCommand;
+
+	global $crosslink_targets_test_formats;
+
+	$command = new CrosslinkTargetsCommand();
+	$command( array(), array( 'format' => 'json' ) );
+	$command( array(), array( 'format' => 'csv' ) );
+	$command( array(), array() );
+
+	$expected_fields = array( 'post_id', 'title', 'category', 'returned', 'inbound_links', 'orphan', 'score' );
+	crosslink_targets_test_assert_same( 'json', $crosslink_targets_test_formats[0]['format'], 'JSON format must be preserved.' );
+	crosslink_targets_test_assert_same( 'csv', $crosslink_targets_test_formats[1]['format'], 'CSV format must be preserved.' );
+	crosslink_targets_test_assert_same( 'table', $crosslink_targets_test_formats[2]['format'], 'Table format must be preserved.' );
+
+	foreach ( $crosslink_targets_test_formats as $formatted ) {
+		crosslink_targets_test_assert_same( $expected_fields, $formatted['fields'], 'Output fields must use the inbound-only contract.' );
+		crosslink_targets_test_assert_same( false, array_key_exists( 'suggested_surface', $formatted['items'][0] ), 'Legacy suggested_surface payload data must be ignored.' );
+	}
+
+	fwrite( STDOUT, "CrosslinkTargetsCommand tests passed.\n" );
+}


### PR DESCRIPTION
## Summary
- remove `suggested_surface` from table, JSON, and CSV presenter output
- describe every result as a target page needing contextual inbound links to it, without prescribing Events or Community destinations
- preserve the zero-inbound orphan versus zero-outbound page distinction
- add focused coverage for all three formats using a legacy analytics payload

## Output contract
Before: `post_id,title,category,returned,inbound_links,orphan,suggested_surface,score`

After: `post_id,title,category,returned,inbound_links,orphan,score`

## Compatibility
The presenter shapes only the documented fields. If the older analytics deployment still returns `suggested_surface`, the CLI silently ignores it; if analytics#122 deploys first and omits the field, output is identical.

## Product model
The report ranks valuable pages with weak inbound-link coverage. Each row is the destination target that needs contextual internal links pointing to it. It does not infer or recommend an outbound Events or Community surface, and this change does not alter taxonomy or community behavior.

## Checks
- `php -l inc/Commands/Analytics/CrosslinkTargetsCommand.php`
- `php -l tests/CrosslinkTargetsCommandTest.php`
- `php tests/QRCodeCommandTest.php`
- `php tests/CrosslinkTargetsCommandTest.php`
- scoped PHPCS via `homeboy review lint ... --changed-only` (passed, no findings)
- PHPStan invoked through the same lint gate; local bundled PHAR could not load (`manifest cannot be larger than 100 MB`), so static analysis could not execute reliably
- Homeboy test umbrella attempted; local WP Codebox recipe-builder export was unavailable, while both repository standalone tests passed directly

Fixes #88.
Follow-up to Extra-Chill/extrachill-analytics#122.