### PR TITLE
feat: manage Local Scene preferences

### DIFF
--- a/homeboy.json
+++ b/homeboy.json
@@ -9,7 +9,8 @@
   "self_checks": {
     "test": [
       "php tests/QRCodeCommandTest.php",
-      "php tests/CrosslinkTargetsCommandTest.php"
+      "php tests/CrosslinkTargetsCommandTest.php",
+      "php tests/UserLocalSceneCommandTest.php"
     ]
   },
   "version_targets": [

--- a/inc/Commands/Users/ProfileCommand.php
+++ b/inc/Commands/Users/ProfileCommand.php
@@ -84,8 +84,8 @@ class ProfileCommand {
 					'Value' => mb_substr( $result['bio'] ?? '', 0, 80 ) . ( mb_strlen( $result['bio'] ?? '' ) > 80 ? '...' : '' ),
 				),
 				array(
-					'Field' => 'local_city',
-					'Value' => $result['local_city'] ? $result['local_city'] : '(none)',
+					'Field' => 'local_scene',
+					'Value' => $this->format_local_scene( $result['local_scene'] ?? null ),
 				),
 				array(
 					'Field' => 'links',
@@ -117,11 +117,17 @@ class ProfileCommand {
 	 * : User bio/description.
 	 *
 	 * [--local-city=<local-city>]
-	 * : Local scene city/region.
+	 * : Deprecated alias for --local-scene.
+	 *
+	 * [--local-scene=<location-slug>]
+	 * : Canonical Events location slug. Pass an empty string to clear it.
+	 *
+	 * [--local-scene-visibility=<visibility>]
+	 * : Local Scene visibility: public or private.
 	 *
 	 * ## EXAMPLES
 	 *
-	 *     wp extrachill users profile update chubes --bio="Founder of Extra Chill" --local-city="Austin, TX"
+	 *     wp extrachill users profile update chubes --bio="Founder of Extra Chill" --local-scene=charleston-sc
 	 *     wp extrachill users profile update 1 --custom-title="Captain Chill"
 	 *
 	 * @when after_wp_load
@@ -132,11 +138,6 @@ class ProfileCommand {
 			WP_CLI::error( 'User not found.' );
 		}
 
-		$ability = wp_get_ability( 'extrachill/update-user-profile' );
-		if ( ! $ability ) {
-			WP_CLI::error( 'extrachill/update-user-profile ability not available.' );
-		}
-
 		$input = array( 'user_id' => (int) $user->ID );
 
 		if ( isset( $assoc_args['custom-title'] ) ) {
@@ -145,18 +146,46 @@ class ProfileCommand {
 		if ( isset( $assoc_args['bio'] ) ) {
 			$input['bio'] = (string) $assoc_args['bio'];
 		}
+
+		$settings_input = array( 'user_id' => (int) $user->ID );
+		if ( isset( $assoc_args['local-scene'] ) ) {
+			$settings_input['local_scene'] = (string) $assoc_args['local-scene'];
+		}
 		if ( isset( $assoc_args['local-city'] ) ) {
-			$input['local_city'] = (string) $assoc_args['local-city'];
+			WP_CLI::warning( '--local-city is deprecated; use --local-scene=<location-slug> instead.' );
+			if ( ! isset( $assoc_args['local-scene'] ) ) {
+				$settings_input['local_scene'] = (string) $assoc_args['local-city'];
+			}
+		}
+		if ( isset( $assoc_args['local-scene-visibility'] ) ) {
+			$settings_input['local_scene_visibility'] = (string) $assoc_args['local-scene-visibility'];
 		}
 
-		$result = $ability->execute( $input );
+		$results = array();
+		if ( count( $input ) > 1 ) {
+			$ability = wp_get_ability( 'extrachill/update-user-profile' );
+			if ( ! $ability ) {
+				WP_CLI::error( 'extrachill/update-user-profile ability not available.' );
+			}
+			$results['profile'] = $ability->execute( $input );
+			if ( is_wp_error( $results['profile'] ) ) {
+				WP_CLI::error( $results['profile']->get_error_message() );
+			}
+		}
 
-		if ( is_wp_error( $result ) ) {
-			WP_CLI::error( $result->get_error_message() );
+		if ( count( $settings_input ) > 1 ) {
+			$ability = wp_get_ability( 'extrachill/update-user-settings' );
+			if ( ! $ability ) {
+				WP_CLI::error( 'extrachill/update-user-settings ability not available.' );
+			}
+			$results['settings'] = $ability->execute( $settings_input );
+			if ( is_wp_error( $results['settings'] ) ) {
+				WP_CLI::error( $results['settings']->get_error_message() );
+			}
 		}
 
 		WP_CLI::success( sprintf( 'Profile updated for user %d (%s).', (int) $user->ID, $user->user_login ) );
-		WP_CLI::log( wp_json_encode( $result, JSON_PRETTY_PRINT ) );
+		WP_CLI::log( wp_json_encode( count( $results ) === 1 ? reset( $results ) : $results, JSON_PRETTY_PRINT ) );
 	}
 
 	/**
@@ -228,5 +257,13 @@ class ProfileCommand {
 		}
 
 		return get_user_by( 'login', $identifier );
+	}
+
+	private function format_local_scene( $local_scene ) {
+		if ( ! is_array( $local_scene ) ) {
+			return '(none)';
+		}
+
+		return $local_scene['slug'] ?? ( $local_scene['name'] ?? '(none)' );
 	}
 }

--- a/inc/Commands/Users/SettingsCommand.php
+++ b/inc/Commands/Users/SettingsCommand.php
@@ -87,6 +87,14 @@ class SettingsCommand {
 					'Value' => $result['pending_email'] ?? '(none)',
 				),
 				array(
+					'Field' => 'local_scene',
+					'Value' => $this->format_local_scene( $result['local_scene'] ?? null ),
+				),
+				array(
+					'Field' => 'local_scene_visibility',
+					'Value' => $result['local_scene_visibility'] ?? 'public',
+				),
+				array(
 					'Field' => 'display_name_options',
 					'Value' => implode( ', ', $result['display_name_options'] ),
 				),
@@ -114,10 +122,20 @@ class SettingsCommand {
 	 * [--display-name=<display-name>]
 	 * : Display name.
 	 *
+	 * [--local-scene=<location-slug>]
+	 * : Canonical Events location slug. Pass an empty string to clear it.
+	 *
+	 * [--local-scene-visibility=<visibility>]
+	 * : Local Scene visibility: public or private.
+	 *
+	 * [--local-city=<location-slug>]
+	 * : Deprecated alias for --local-scene.
+	 *
 	 * ## EXAMPLES
 	 *
 	 *     wp extrachill users settings update chubes --first-name=Chris --last-name=Huber
 	 *     wp extrachill users settings update 1 --display-name="Chris Huber"
+	 *     wp extrachill users settings update chubes --local-scene=charleston-sc --local-scene-visibility=public
 	 *
 	 * @when after_wp_load
 	 */
@@ -142,6 +160,18 @@ class SettingsCommand {
 		}
 		if ( isset( $assoc_args['display-name'] ) ) {
 			$input['display_name'] = (string) $assoc_args['display-name'];
+		}
+		if ( isset( $assoc_args['local-scene'] ) ) {
+			$input['local_scene'] = (string) $assoc_args['local-scene'];
+		}
+		if ( isset( $assoc_args['local-city'] ) ) {
+			WP_CLI::warning( '--local-city is deprecated; use --local-scene=<location-slug> instead.' );
+			if ( ! isset( $assoc_args['local-scene'] ) ) {
+				$input['local_scene'] = (string) $assoc_args['local-city'];
+			}
+		}
+		if ( isset( $assoc_args['local-scene-visibility'] ) ) {
+			$input['local_scene_visibility'] = (string) $assoc_args['local-scene-visibility'];
 		}
 
 		$result = $ability->execute( $input );
@@ -269,5 +299,13 @@ class SettingsCommand {
 		}
 
 		return get_user_by( 'login', $identifier );
+	}
+
+	private function format_local_scene( $local_scene ) {
+		if ( ! is_array( $local_scene ) ) {
+			return '(none)';
+		}
+
+		return $local_scene['slug'] ?? ( $local_scene['name'] ?? '(none)' );
 	}
 }

--- a/tests/UserLocalSceneCommandTest.php
+++ b/tests/UserLocalSceneCommandTest.php
@@ -1,0 +1,112 @@
+<?php
+/**
+ * Focused behavior tests for canonical Local Scene CLI adapters.
+ */
+
+define( 'ABSPATH', __DIR__ . '/' );
+
+class UserLocalSceneCommandTestError extends RuntimeException {}
+
+class WP_CLI {
+	public static $messages = array();
+
+	public static function error( $message ) {
+		throw new UserLocalSceneCommandTestError( $message );
+	}
+
+	public static function success( $message ) {
+		self::$messages[] = 'Success: ' . $message;
+	}
+
+	public static function warning( $message ) {
+		self::$messages[] = 'Warning: ' . $message;
+	}
+
+	public static function log( $message ) {
+		self::$messages[] = $message;
+	}
+}
+
+class UserLocalSceneTestAbility {
+	public $inputs = array();
+
+	public function execute( $input ) {
+		$this->inputs[] = $input;
+		return $input;
+	}
+}
+
+$user_local_scene_abilities = array();
+
+function get_user_by( $field, $value ) {
+	return (object) array( 'ID' => 7, 'user_login' => 'chubes' );
+}
+
+function is_email( $value ) {
+	return false;
+}
+
+function wp_get_ability( $name ) {
+	global $user_local_scene_abilities;
+	return $user_local_scene_abilities[ $name ] ?? null;
+}
+
+function is_wp_error( $value ) {
+	return false;
+}
+
+function wp_json_encode( $value, $flags = 0 ) {
+	return json_encode( $value, $flags );
+}
+
+function user_local_scene_assert_same( $expected, $actual, $message ) {
+	if ( $expected !== $actual ) {
+		throw new RuntimeException( $message . '\nExpected: ' . var_export( $expected, true ) . '\nActual: ' . var_export( $actual, true ) );
+	}
+}
+
+require_once dirname( __DIR__ ) . '/inc/Commands/Users/SettingsCommand.php';
+require_once dirname( __DIR__ ) . '/inc/Commands/Users/ProfileCommand.php';
+
+use ExtraChill\CLI\Commands\Users\ProfileCommand;
+use ExtraChill\CLI\Commands\Users\SettingsCommand;
+
+$settings_ability = new UserLocalSceneTestAbility();
+$profile_ability  = new UserLocalSceneTestAbility();
+$user_local_scene_abilities = array(
+	'extrachill/update-user-settings' => $settings_ability,
+	'extrachill/update-user-profile'  => $profile_ability,
+);
+
+( new SettingsCommand() )->update(
+	array( 'chubes' ),
+	array(
+		'local-scene'            => 'charleston-sc',
+		'local-scene-visibility' => 'private',
+	)
+);
+user_local_scene_assert_same(
+	array( array( 'user_id' => 7, 'local_scene' => 'charleston-sc', 'local_scene_visibility' => 'private' ) ),
+	$settings_ability->inputs,
+	'Settings update must pass canonical Local Scene fields to the Users settings ability.'
+);
+
+$settings_ability->inputs = array();
+WP_CLI::$messages         = array();
+( new ProfileCommand() )->update(
+	array( 'chubes' ),
+	array( 'local-city' => 'austin-tx' )
+);
+user_local_scene_assert_same(
+	array( array( 'user_id' => 7, 'local_scene' => 'austin-tx' ) ),
+	$settings_ability->inputs,
+	'Legacy local-city must write only canonical Local Scene state through the settings ability.'
+);
+user_local_scene_assert_same( array(), $profile_ability->inputs, 'Legacy local-city must not write parallel profile state.' );
+user_local_scene_assert_same(
+	'Warning: --local-city is deprecated; use --local-scene=<location-slug> instead.',
+	WP_CLI::$messages[0],
+	'Legacy local-city must emit clear deprecation guidance.'
+);
+
+fwrite( STDOUT, "UserLocalSceneCommand tests passed.\n" );


### PR DESCRIPTION
Adds canonical Local Scene and visibility commands through Users Abilities. Keeps --local-city as a deprecated alias without parallel writes. Focused command tests pass. Fixes #90.