### PR TITLE
feat: add ability-backed revenue commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,30 @@ installs where a `user_login` collides with a numeric user ID (e.g. a login of
 but noisy `Ambiguous user match detected` warning before the output, which
 clutters scripted captures. Omit `--user` entirely.
 
+### Analytics — Revenue
+
+Revenue commands are thin adapters over the Data Machine Business and Extra
+Chill Analytics abilities. Fetches replace the deterministic snapshot for the
+source site and period, so repeating a monthly fetch is safe.
+
+The legacy `revenue import` and `revenue batches` commands are intentionally
+retired. They bypassed the ability-owned ingestion identity and persistence
+contract; use `revenue fetch` for supported Mediavine ingestion.
+
+```bash
+# Fetch a month directly from Mediavine and replace that period's snapshot.
+wp extrachill analytics revenue fetch --start=2026-05-01 --end=2026-05-31 --period=2026-05
+
+# Inspect resolved pages without direct database access.
+wp extrachill analytics revenue pages --period=2026-05 --min-views=100 --sort-by=derived_rpm
+
+# Inspect unresolved report routes separately.
+wp extrachill analytics revenue pages --period=2026-05 --cohort=unresolved --format=csv
+
+# Run store-integrity checks. Warnings remain successful; failures exit nonzero.
+wp extrachill analytics revenue diagnose --format=json
+```
+
 ### Output Formats
 
 All list/query commands support `--format=table|json|csv`:

--- a/README.md
+++ b/README.md
@@ -114,6 +114,10 @@ Revenue commands are thin adapters over the Data Machine Business and Extra
 Chill Analytics abilities. Fetches replace the deterministic snapshot for the
 source site and period, so repeating a monthly fetch is safe.
 
+Use `--mode=additive --snapshot=<label>` only for an intentional parallel
+snapshot; the ingestion ability validates that mode and snapshot. The default
+`replace` mode owns deterministic snapshot identity in analytics.
+
 The legacy `revenue import` and `revenue batches` commands are intentionally
 retired. They bypassed the ability-owned ingestion identity and persistence
 contract; use `revenue fetch` for supported Mediavine ingestion.

--- a/homeboy.json
+++ b/homeboy.json
@@ -10,7 +10,8 @@
     "test": [
       "php tests/QRCodeCommandTest.php",
       "php tests/CrosslinkTargetsCommandTest.php",
-      "php tests/UserLocalSceneCommandTest.php"
+      "php tests/UserLocalSceneCommandTest.php",
+      "php tests/RevenueCommandTest.php"
     ]
   },
   "version_targets": [

--- a/inc/Commands/Analytics/RevenueCommand.php
+++ b/inc/Commands/Analytics/RevenueCommand.php
@@ -36,8 +36,18 @@ class RevenueCommand {
 	 * ---
 	 * default: extrachill.com
 	 * ---
+	 * [--mode=<mode>]
+	 * : Ingestion mode. Additive snapshots require --snapshot.
+	 * ---
+	 * default: replace
+	 * options:
+	 *   - replace
+	 *   - additive
+	 * ---
+	 * [--snapshot=<label>]
+	 * : Explicit snapshot label, required only for --mode=additive.
 	 * [--dry-run]
-	 * : Fetch and plan deterministic replacement without writing.
+	 * : Fetch and plan ingestion without writing.
 	 *
 	 * ## EXAMPLES
 	 *
@@ -52,6 +62,14 @@ class RevenueCommand {
 		$ingest  = $this->ability( 'extrachill/ingest-revenue', 'Extra Chill Analytics' );
 		$periods = $this->fetch_periods( $assoc_args );
 		$dry_run = isset( $assoc_args['dry-run'] );
+		$mode    = $assoc_args['mode'] ?? 'replace';
+		$snapshot = $assoc_args['snapshot'] ?? '';
+		if ( ! in_array( $mode, array( 'replace', 'additive' ), true ) ) {
+			WP_CLI::error( '--mode must be replace or additive.' );
+		}
+		if ( 'additive' === $mode && '' === $snapshot ) {
+			WP_CLI::error( '--snapshot is required when --mode=additive.' );
+		}
 
 		$input = array( 'action' => 'backfill', 'periods' => $periods );
 		if ( isset( $assoc_args['site-id'] ) && '' !== $assoc_args['site-id'] ) {
@@ -63,12 +81,16 @@ class RevenueCommand {
 		$this->assert_success( $report, 'Mediavine fetch failed.' );
 
 		$summaries = array();
+		$errors    = array();
 		foreach ( (array) ( $report['periods'] ?? array() ) as $summary ) {
 			if ( ! empty( $summary['error'] ) ) {
-				WP_CLI::warning( sprintf( 'Period %s failed: %s', $summary['period'] ?? '(window)', $summary['error'] ) );
+				$errors[] = sprintf( '%s: %s', $summary['period'] ?? '(window)', $summary['error'] );
 				continue;
 			}
 			$summaries[ (string) ( $summary['period'] ?? '' ) ] = $summary;
+		}
+		if ( ! empty( $errors ) ) {
+			WP_CLI::error( 'Mediavine failed one or more periods; no revenue was ingested: ' . implode( '; ', $errors ) );
 		}
 
 		$rows_by_period = array();
@@ -90,6 +112,8 @@ class RevenueCommand {
 					'period'       => $period,
 					'period_start' => $this->report_date( $summary, 'start_date', 'start' ),
 					'period_end'   => $this->report_date( $summary, 'end_date', 'end' ),
+					'mode'         => $mode,
+					'snapshot'     => $snapshot,
 					'dry_run'      => $dry_run,
 				)
 			);
@@ -111,7 +135,7 @@ class RevenueCommand {
 		}
 
 		if ( ! $dry_run ) {
-			WP_CLI::success( 'Mediavine fetch complete. Re-fetching a period replaces its deterministic snapshot.' );
+			WP_CLI::success( 'additive' === $mode ? 'Mediavine fetch complete.' : 'Mediavine fetch complete. Re-fetching a period replaces its deterministic snapshot.' );
 		}
 	}
 
@@ -163,13 +187,15 @@ class RevenueCommand {
 		$this->assert_success( $result, 'Revenue pages query failed.' );
 
 		$format = $assoc_args['format'] ?? 'table';
-		if ( 'table' !== $format ) {
+		if ( 'json' === $format ) {
 			WP_CLI::print_value( $result, array( 'format' => $format ) );
 			return;
 		}
 
-		WP_CLI::log( sprintf( 'Content Revenue Pages - %s', $result['window'] ?? '' ) );
-		Utils\format_items( 'table', (array) ( $result['pages'] ?? array() ), $this->page_fields() );
+		if ( 'table' === $format ) {
+			WP_CLI::log( sprintf( 'Content Revenue Pages - %s', $result['window'] ?? '' ) );
+		}
+		Utils\format_items( $format, (array) ( $result['pages'] ?? array() ), $this->page_fields() );
 	}
 
 	/**
@@ -206,16 +232,20 @@ class RevenueCommand {
 		$this->assert_success( $result, 'Revenue rollup failed.' );
 
 		$format = $assoc_args['format'] ?? 'table';
-		if ( 'table' !== $format ) {
+		if ( 'json' === $format ) {
 			WP_CLI::print_value( $result, array( 'format' => $format ) );
 			return;
 		}
 
 		$limit = max( 1, (int) ( $assoc_args['limit'] ?? 50 ) );
+		$rows  = array();
 		foreach ( (array) ( $result['rollups'] ?? array() ) as $axis => $buckets ) {
-			WP_CLI::log( 'by_format' === $axis ? 'By content format:' : 'By category:' );
-			Utils\format_items( 'table', array_slice( $buckets, 0, $limit ), array( 'bucket', 'pages', 'views', 'revenue', 'dollars_per_page', 'rpm' ) );
+			foreach ( array_slice( $buckets, 0, $limit ) as $bucket ) {
+				$bucket['axis'] = $axis;
+				$rows[]         = $bucket;
+			}
 		}
+		Utils\format_items( $format, $rows, array( 'axis', 'bucket', 'pages', 'views', 'revenue', 'dollars_per_page', 'rpm' ) );
 	}
 
 	/**
@@ -241,12 +271,12 @@ class RevenueCommand {
 		$this->assert_success( $result, 'Revenue arc failed.' );
 
 		$format = $assoc_args['format'] ?? 'table';
-		if ( 'table' !== $format ) {
+		if ( 'json' === $format ) {
 			WP_CLI::print_value( $result, array( 'format' => $format ) );
 			return;
 		}
 
-		Utils\format_items( 'table', (array) ( $result['series'] ?? array() ), array( 'period', 'pages', 'views', 'revenue', 'mom_delta', 'mom_pct', 'rpm' ) );
+		Utils\format_items( $format, (array) ( $result['series'] ?? array() ), array( 'period', 'pages', 'views', 'revenue', 'mom_delta', 'mom_pct', 'rpm' ) );
 	}
 
 	/**
@@ -281,11 +311,14 @@ class RevenueCommand {
 		$this->assert_success( $result, 'Revenue diagnostics failed.' );
 
 		$format = $assoc_args['format'] ?? 'table';
-		if ( 'table' === $format ) {
-			WP_CLI::log( sprintf( 'Content Revenue Diagnostics - %s - %s', $result['window'] ?? '', strtoupper( $result['overall_status'] ?? 'fail' ) ) );
-			Utils\format_items( 'table', (array) ( $result['checks'] ?? array() ), array( 'check', 'status', 'evidence', 'totals' ) );
-		} else {
+		if ( 'json' === $format ) {
 			WP_CLI::print_value( $result, array( 'format' => $format ) );
+		} else {
+			$checks = $this->diagnostic_rows( (array) ( $result['checks'] ?? array() ) );
+			if ( 'table' === $format ) {
+				WP_CLI::log( sprintf( 'Content Revenue Diagnostics - %s - %s', $result['window'] ?? '', strtoupper( $result['overall_status'] ?? 'fail' ) ) );
+			}
+			Utils\format_items( $format, $checks, array( 'check', 'status', 'evidence', 'totals' ) );
 		}
 
 		if ( 'fail' === ( $result['overall_status'] ?? 'fail' ) ) {
@@ -307,14 +340,35 @@ class RevenueCommand {
 			if ( ! is_array( $periods ) || empty( $periods ) ) {
 				WP_CLI::error( '--periods must be a non-empty JSON array of {period, start_date, end_date} objects.' );
 			}
-			return $periods;
+			return $this->validate_periods( $periods );
 		}
 
 		$period = array( 'period' => $assoc_args['period'] ?? '', 'start_date' => $assoc_args['start'] ?? '', 'end_date' => $assoc_args['end'] ?? '' );
-		if ( '' === $period['period'] || '' === $period['start_date'] || '' === $period['end_date'] ) {
-			WP_CLI::error( '--start, --end, and --period are required unless --periods is provided.' );
+		return $this->validate_periods( array( $period ) );
+	}
+
+	private function validate_periods( $periods ) {
+		$labels = array();
+		foreach ( $periods as $entry ) {
+			if ( ! is_array( $entry ) || ! isset( $entry['period'] ) || '' === trim( (string) $entry['period'] ) || ! $this->valid_date( $entry['start_date'] ?? '' ) || ! $this->valid_date( $entry['end_date'] ?? '' ) ) {
+				WP_CLI::error( 'Every period must include a non-empty period plus valid start_date and end_date values in Y-m-d format.' );
+			}
+			if ( $entry['start_date'] > $entry['end_date'] ) {
+				WP_CLI::error( 'Every period start_date must be on or before end_date.' );
+			}
+			if ( isset( $labels[ $entry['period'] ] ) ) {
+				WP_CLI::error( sprintf( 'Duplicate period label: %s.', $entry['period'] ) );
+			}
+			$labels[ $entry['period'] ] = true;
 		}
-		return array( $period );
+		return $periods;
+	}
+
+	private function valid_date( $value ) {
+		if ( ! is_string( $value ) || ! preg_match( '/^(\d{4})-(\d{2})-(\d{2})$/', $value, $matches ) ) {
+			return false;
+		}
+		return checkdate( (int) $matches[2], (int) $matches[3], (int) $matches[1] );
 	}
 
 	private function ingest_rows( $rows ) {
@@ -342,8 +396,13 @@ class RevenueCommand {
 	}
 
 	private function report_date( $summary, $requested_key, $canonical_key ) {
-		$canonical = $summary['provenance']['period']['canonical'][ $canonical_key ] ?? '';
-		return '' !== $canonical ? str_replace( '/', '-', (string) $canonical ) : (string) ( $summary[ $requested_key ] ?? '' );
+		$requested = (string) ( $summary[ $requested_key ] ?? '' );
+		$canonical = $summary['provenance']['period']['canonical'][ $canonical_key ] ?? null;
+		if ( ! is_string( $canonical ) || '' === $canonical ) {
+			return $requested;
+		}
+		$canonical = str_replace( '/', '-', $canonical );
+		return $canonical === $requested ? $canonical : $requested;
 	}
 
 	private function assert_success( $result, $fallback ) {
@@ -356,6 +415,17 @@ class RevenueCommand {
 	}
 
 	private function page_fields() {
-		return array( 'cohort', 'post_id', 'title', 'url', 'categories', 'format', 'route_family', 'views', 'revenue', 'derived_rpm', 'source_rpm', 'cpm', 'viewability', 'fill_rate', 'impressions_per_pageview', 'zero_views', 'benchmark_opportunity' );
+		return array( 'cohort', 'post_id', 'title', 'url', 'format', 'views', 'revenue', 'dollars_per_page', 'derived_rpm', 'source_rpm', 'cpm', 'viewability', 'fill_rate', 'impressions_per_pageview', 'benchmark_score', 'benchmark_opportunity', 'zero_views' );
+	}
+
+	private function diagnostic_rows( $checks ) {
+		return array_map(
+			static function ( $check ) {
+				$check['evidence'] = wp_json_encode( $check['evidence'] ?? array() );
+				$check['totals']   = wp_json_encode( $check['totals'] ?? array() );
+				return $check;
+			},
+			$checks
+		);
 	}
 }

--- a/inc/Commands/Analytics/RevenueCommand.php
+++ b/inc/Commands/Analytics/RevenueCommand.php
@@ -1,21 +1,6 @@
 <?php
 /**
- * Analytics Revenue CLI Command
- *
- * The content-category revenue + RPM lens. Makes the manual "join a Mediavine
- * Pages CSV to content categories" stitch repeatable: import the CSV, then roll
- * revenue up by content format or category with the honest $/page metric.
- *
- * Mediavine exposes NO per-page revenue API — its Control Panel plugin only
- * fetches ad-script settings — so the CSV import is the only path to per-URL
- * revenue. The `import` subcommand ingests a Mediavine Pages export; `rollup`
- * wraps the extrachill/get-content-revenue ability to report pages, views,
- * revenue, RPM, and $/page per format/category, with a recent-vs-lifetime lens.
- *
- * Why $/page and not RPM: RPM is a multiplier, not a volume measure. A format
- * can show a high RPM yet a tiny $/page because it has almost no views ("high
- * RPM on tiny volume = pennies"). $/page (revenue/pages) is the only honest
- * answer to "is this format worth producing," so the rollup ranks on it.
+ * Analytics Revenue CLI Command.
  *
  * @package ExtraChill\CLI\Commands\Analytics
  */
@@ -25,431 +10,190 @@ namespace ExtraChill\CLI\Commands\Analytics;
 use WP_CLI;
 use WP_CLI\Utils;
 
-if ( ! defined( 'ABSPATH' ) ) {
-	exit;
-}
+defined( 'ABSPATH' ) || exit;
 
+/**
+ * Thin presentation adapters for the analytics revenue abilities.
+ */
 class RevenueCommand {
-
 	/**
-	 * Fetch per-period Mediavine revenue over HTTP and load it into the store.
-	 *
-	 * The no-manual-CSV path. Wraps the datamachine/mediavine-reports DMB ability
-	 * (direct GraphQL login + per-page CSV report — no browser, no manual export)
-	 * and feeds the returned rows straight into the SAME revenue importer the
-	 * `import` subcommand uses, so slug→post resolution, period stamping, and the
-	 * arc all behave identically. Pass a single window (--start/--end + --period)
-	 * for one bucket, or --periods for a multi-month backfill in one shot.
-	 *
-	 * Credentials live server-side in the datamachine_mediavine_config option —
-	 * never on the command line. Set them once:
-	 *   wp option update datamachine_mediavine_config '{"email":"...","password":"..."}' --format=json
+	 * Fetch Mediavine period reports and replace their deterministic snapshots.
 	 *
 	 * ## OPTIONS
 	 *
 	 * [--start=<date>]
-	 * : Window start (Y-m-d). Used with --end for a single-period fetch.
-	 *
+	 * : Window start (Y-m-d). Used with --end and --period for one period.
 	 * [--end=<date>]
-	 * : Window end (Y-m-d). Used with --start for a single-period fetch.
-	 *
+	 * : Window end (Y-m-d). Used with --start and --period for one period.
 	 * [--period=<period>]
-	 * : Period label (e.g. 2026-05) to stamp the fetched rows with — what the arc groups by.
-	 *
+	 * : Period label, such as 2026-05.
 	 * [--periods=<json>]
-	 * : JSON array for a backfill: [{"period":"2026-05","start_date":"2026-05-01","end_date":"2026-05-31"}, ...].
-	 *   When supplied, --start/--end/--period are ignored and each entry is imported as its own batch.
-	 *
+	 * : JSON array of {period, start_date, end_date} entries for a backfill.
 	 * [--site-id=<id>]
-	 * : Mediavine site id. Defaults to the configured/Extra Chill default.
-	 *
+	 * : Mediavine site ID.
 	 * [--hostname=<host>]
-	 * : Hostname for slug→post resolution.
+	 * : WordPress hostname used by the ingestion ability for route resolution.
 	 * ---
 	 * default: extrachill.com
 	 * ---
-	 *
 	 * [--dry-run]
-	 * : Fetch and resolve but do not write to the store.
+	 * : Fetch and plan deterministic replacement without writing.
 	 *
 	 * ## EXAMPLES
 	 *
-	 *     # One month, fetched live and loaded:
 	 *     wp extrachill analytics revenue fetch --start=2026-05-01 --end=2026-05-31 --period=2026-05
-	 *
-	 *     # Multi-month backfill in one command:
-	 *     wp extrachill analytics revenue fetch --periods='[{"period":"2026-04","start_date":"2026-04-01","end_date":"2026-04-30"},{"period":"2026-05","start_date":"2026-05-01","end_date":"2026-05-31"}]'
-	 *
-	 *     wp extrachill analytics revenue fetch --start=2026-05-01 --end=2026-05-31 --period=2026-05 --dry-run
+	 *     wp extrachill analytics revenue fetch --periods='[{"period":"2026-04","start_date":"2026-04-01","end_date":"2026-04-30"}]'
 	 *
 	 * @subcommand fetch
 	 * @when after_wp_load
 	 */
 	public function fetch( $args, $assoc_args ) {
-		$ability = wp_get_ability( 'datamachine/mediavine-reports' );
-		if ( ! $ability ) {
-			WP_CLI::error( 'datamachine/mediavine-reports ability not found. Is Data Machine Business active and up to date (PR #48)?' );
-		}
-		if ( ! function_exists( 'extrachill_analytics_revenue_import_csv' ) ) {
-			WP_CLI::error( 'extrachill-analytics revenue importer not available. Is Extra Chill Analytics active and up to date?' );
-		}
+		$reports = $this->ability( 'datamachine/mediavine-reports', 'Data Machine Business' );
+		$ingest  = $this->ability( 'extrachill/ingest-revenue', 'Extra Chill Analytics' );
+		$periods = $this->fetch_periods( $assoc_args );
+		$dry_run = isset( $assoc_args['dry-run'] );
 
-		$hostname = $assoc_args['hostname'] ?? 'extrachill.com';
-		$dry_run  = isset( $assoc_args['dry-run'] );
-
-		// Build the period list: an explicit --periods backfill, or one window.
-		$periods = array();
-		if ( ! empty( $assoc_args['periods'] ) ) {
-			$decoded = json_decode( (string) $assoc_args['periods'], true );
-			if ( ! is_array( $decoded ) || empty( $decoded ) ) {
-				WP_CLI::error( '--periods must be a non-empty JSON array of {period, start_date, end_date} objects.' );
-			}
-			$periods = $decoded;
-		} else {
-			$periods[] = array(
-				'period'     => $assoc_args['period'] ?? '',
-				'start_date' => $assoc_args['start'] ?? '',
-				'end_date'   => $assoc_args['end'] ?? '',
-			);
+		$input = array( 'action' => 'backfill', 'periods' => $periods );
+		if ( isset( $assoc_args['site-id'] ) && '' !== $assoc_args['site-id'] ) {
+			$input['site_id'] = (string) $assoc_args['site-id'];
 		}
 
-		$ability_input = array(
-			'action'  => 'backfill',
-			'periods' => $periods,
-		);
-		if ( ! empty( $assoc_args['site-id'] ) ) {
-			$ability_input['site_id'] = $assoc_args['site-id'];
-		}
+		WP_CLI::log( sprintf( 'Fetching %d period(s) from Mediavine...', count( $periods ) ) );
+		$report = $reports->execute( $input );
+		$this->assert_success( $report, 'Mediavine fetch failed.' );
 
-		WP_CLI::log( sprintf( 'Fetching %d period(s) from Mediavine…', count( $periods ) ) );
-
-		$result = $ability->execute( $ability_input );
-
-		if ( is_wp_error( $result ) ) {
-			WP_CLI::error( $result->get_error_message() );
-		}
-		if ( empty( $result['success'] ) ) {
-			WP_CLI::error( $result['error'] ?? 'Mediavine fetch failed.' );
-		}
-
-		$rows = (array) ( $result['results'] ?? array() );
-
-		// Surface any per-period fetch errors the ability reported.
-		foreach ( (array) ( $result['periods'] ?? array() ) as $summary ) {
+		$summaries = array();
+		foreach ( (array) ( $report['periods'] ?? array() ) as $summary ) {
 			if ( ! empty( $summary['error'] ) ) {
-				WP_CLI::warning( sprintf( 'Period %s failed: %s', ( '' !== ( $summary['period'] ?? '' ) ? $summary['period'] : '(window)' ), $summary['error'] ) );
+				WP_CLI::warning( sprintf( 'Period %s failed: %s', $summary['period'] ?? '(window)', $summary['error'] ) );
+				continue;
 			}
+			$summaries[ (string) ( $summary['period'] ?? '' ) ] = $summary;
 		}
 
-		if ( empty( $rows ) ) {
+		$rows_by_period = array();
+		foreach ( (array) ( $report['results'] ?? array() ) as $row ) {
+			$rows_by_period[ (string) ( $row['period'] ?? '' ) ][] = $row;
+		}
+		if ( empty( $rows_by_period ) ) {
 			WP_CLI::error( 'Mediavine returned no rows for the requested period(s).' );
 		}
 
-		// Group rows by their stamped period so each lands in its own batch —
-		// identical to importing one monthly CSV per period.
-		$by_period = array();
-		foreach ( $rows as $row ) {
-			$period                 = (string) ( $row['period'] ?? '' );
-			$by_period[ $period ][] = $row;
-		}
-
-		$total_parsed     = 0;
-		$total_resolved   = 0;
-		$total_unresolved = 0;
-		$total_imported   = 0;
-
-		foreach ( $by_period as $period => $period_rows ) {
-			$csv_path = self::write_rows_csv( $period_rows );
-			if ( is_wp_error( $csv_path ) ) {
-				WP_CLI::warning( sprintf( 'Period %s: %s', ( '' !== $period ? $period : 'all-time' ), $csv_path->get_error_message() ) );
-				continue;
-			}
-
-			$import = extrachill_analytics_revenue_import_csv(
-				$csv_path,
+		foreach ( $rows_by_period as $period => $rows ) {
+			$summary = $summaries[ $period ] ?? array();
+			$result  = $ingest->execute(
 				array(
-					'period'   => $period,
-					'hostname' => $hostname,
-					'dry_run'  => $dry_run,
+					'rows'         => $this->ingest_rows( $rows ),
+					'hostname'     => $assoc_args['hostname'] ?? 'extrachill.com',
+					'source'       => 'mediavine',
+					'source_site'  => $this->source_site( $summary, $report ),
+					'period'       => $period,
+					'period_start' => $this->report_date( $summary, 'start_date', 'start' ),
+					'period_end'   => $this->report_date( $summary, 'end_date', 'end' ),
+					'dry_run'      => $dry_run,
 				)
 			);
-
-			wp_delete_file( $csv_path );
-
-			if ( empty( $import['success'] ) ) {
-				WP_CLI::warning( sprintf( 'Period %s import failed: %s', ( '' !== $period ? $period : 'all-time' ), $import['error'] ?? 'unknown' ) );
-				continue;
-			}
-
-			$total_parsed     += (int) $import['rows'];
-			$total_resolved   += (int) $import['resolved'];
-			$total_unresolved += (int) $import['unresolved'];
-			$total_imported   += (int) $import['imported'];
-
+			$this->assert_success( $result, sprintf( 'Revenue ingestion failed for period %s.', $period ) );
+			$identity = (array) ( $result['identity'] ?? array() );
 			WP_CLI::log(
 				sprintf(
-					'  %s — batch %s · parsed %d · resolved %d · unresolved %d · imported %d',
-					( '' !== $period ? $period : 'all-time' ),
-					$import['batch'],
-					(int) $import['rows'],
-					(int) $import['resolved'],
-					(int) $import['unresolved'],
-					(int) $import['imported']
+					'  %s - snapshot %s - rows %d - resolved %d - unresolved %d - inserted %d - replaced %d%s',
+					$period ?: 'all-time',
+					$identity['import_batch'] ?? '(unknown)',
+					(int) ( $result['rows'] ?? 0 ),
+					(int) ( $result['resolved'] ?? 0 ),
+					(int) ( $result['unresolved'] ?? 0 ),
+					(int) ( $result['inserted'] ?? 0 ),
+					(int) ( $result['replaced'] ?? 0 ),
+					$dry_run ? ' (DRY RUN)' : ''
 				)
 			);
 		}
 
-		WP_CLI::log( '' );
-		WP_CLI::log(
-			sprintf(
-				'Totals across %d period(s): parsed %d · resolved %d · unresolved %d · imported %d%s',
-				count( $by_period ),
-				$total_parsed,
-				$total_resolved,
-				$total_unresolved,
-				$total_imported,
-				$dry_run ? ' (DRY RUN — nothing written)' : ''
-			)
-		);
-
 		if ( ! $dry_run ) {
-			WP_CLI::success( 'Mediavine fetch complete. See the arc with: wp extrachill analytics revenue arc' );
+			WP_CLI::success( 'Mediavine fetch complete. Re-fetching a period replaces its deterministic snapshot.' );
 		}
 	}
 
 	/**
-	 * Write ability rows to a temp CSV in the importer's expected header format.
-	 *
-	 * The mediavine-reports ability already returns rows keyed by the same tokens
-	 * the importer matches (slug, views, revenue, rpm, cpm, viewability, fillRate,
-	 * impressionsPerPageview), so we just serialize them to a CSV the existing
-	 * importer can stream — reusing all of its slug→post resolution and store
-	 * logic rather than duplicating it.
-	 *
-	 * @param array $rows Ability rows.
-	 * @return string|\WP_Error Temp CSV path or error.
-	 */
-	private static function write_rows_csv( array $rows ) {
-		$headers = array( 'slug', 'views', 'revenue', 'rpm', 'cpm', 'viewability', 'fillRate', 'impressionsPerPageview' );
-
-		$tmp = wp_tempnam( 'mediavine-revenue' );
-		if ( ! $tmp ) {
-			return new \WP_Error( 'mediavine_tmp_failed', 'Could not create a temp file for the fetched rows.' );
-		}
-
-		$handle = fopen( $tmp, 'w' ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_read_fopen -- streaming CSV write to a temp file; WP_Filesystem has no streaming writer.
-		if ( false === $handle ) {
-			return new \WP_Error( 'mediavine_tmp_open', 'Could not open the temp CSV for writing.' );
-		}
-
-		fputcsv( $handle, $headers, ',', '"', '\\' );
-
-		foreach ( $rows as $row ) {
-			fputcsv(
-				$handle,
-				array(
-					$row['slug'] ?? '',
-					$row['views'] ?? 0,
-					$row['revenue'] ?? 0,
-					$row['rpm'] ?? 0,
-					$row['cpm'] ?? 0,
-					$row['viewability'] ?? 0,
-					$row['fillRate'] ?? 0,
-					$row['impressionsPerPageview'] ?? 0,
-				),
-				',',
-				'"',
-				'\\'
-			);
-		}
-
-		fclose( $handle ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_read_fclose -- paired with the streaming fopen above.
-
-		return $tmp;
-	}
-
-	/**
-	 * Import a Mediavine Pages CSV into the revenue store.
-	 *
-	 * Mediavine has NO per-page revenue API (its Control Panel plugin only fetches
-	 * ad-serving config), so this CSV import is the only path. The flat Mediavine
-	 * pages export is also TIME-BLIND — no date column, one cumulative lifetime
-	 * total per URL — so to build a real revenue arc the operator exports a
-	 * DATE-RANGED (monthly) CSV from the Mediavine dashboard and passes the period
-	 * here via --period=YYYY-MM. Each row is resolved to a WordPress post and
-	 * stamped with that period; re-importing the same (period, batch) is idempotent.
+	 * List page-level Mediavine delivery metrics.
 	 *
 	 * ## OPTIONS
 	 *
-	 * <csv>
-	 * : Absolute path to the Mediavine Pages CSV export.
-	 *
 	 * [--period=<period>]
-	 * : Time bucket these rows belong to: YYYY-MM (a monthly export), YYYY (a year),
-	 *   or omitted for the flat lifetime file (lands in the "all-time" bucket). This
-	 *   is what the `arc` revenue time-series groups by — supply it for monthly exports.
-	 *
 	 * [--period-start=<date>]
-	 * : Explicit window start (Y-m-d) override. Defaults to the start derived from --period.
-	 *
 	 * [--period-end=<date>]
-	 * : Explicit window end (Y-m-d) override. Defaults to the end derived from --period.
-	 *
 	 * [--batch=<label>]
-	 * : Import batch label. Defaults to a label derived from the filename + period.
-	 *
+	 * [--blog-id=<id>]
 	 * [--hostname=<host>]
-	 * : Hostname whose pages map to this blog's posts.
+	 * [--cohort=<cohort>]
+	 * : resolved, unresolved, or all.
 	 * ---
-	 * default: extrachill.com
+	 * default: resolved
 	 * ---
+	 * [--min-views=<n>]
+	 * [--sort-by=<metric>]
+	 * : views, revenue, derived_rpm, source_rpm, cpm, viewability, fill_rate, impressions_per_pageview, dollars_per_page, or benchmark_opportunity.
+	 * [--order=<direction>]
+	 * : desc or asc.
+	 * [--limit=<n>]
+	 * [--format=<format>]
+	 * : table, json, or csv.
 	 *
-	 * [--dry-run]
-	 * : Parse and resolve but do not write to the store.
-	 *
-	 * ## EXAMPLES
-	 *
-	 *     # Flat lifetime file (time-blind — good for category $/page, NOT the arc):
-	 *     wp extrachill analytics revenue import /tmp/mediavine-all-time.csv
-	 *
-	 *     # Monthly exports build the revenue arc — one --period per file:
-	 *     wp extrachill analytics revenue import /tmp/mv-2026-05.csv --period=2026-05
-	 *     wp extrachill analytics revenue import /tmp/mv-2026-06.csv --period=2026-06
-	 *
-	 *     wp extrachill analytics revenue import /tmp/mv.csv --dry-run
-	 *
-	 * @subcommand import
+	 * @subcommand pages
 	 * @when after_wp_load
 	 */
-	public function import( $args, $assoc_args ) {
-		if ( ! function_exists( 'extrachill_analytics_revenue_import_csv' ) ) {
-			WP_CLI::error( 'extrachill-analytics revenue importer not available. Is Extra Chill Analytics active and up to date?' );
-		}
-
-		$file = $args[0] ?? '';
-		if ( '' === $file || ! is_readable( $file ) ) {
-			WP_CLI::error( "CSV not readable: {$file}" );
-		}
-
-		$result = extrachill_analytics_revenue_import_csv(
-			$file,
+	public function pages( $args, $assoc_args ) {
+		$ability = $this->ability( 'extrachill/get-content-revenue-pages', 'Extra Chill Analytics' );
+		$result  = $ability->execute(
 			array(
 				'period'       => $assoc_args['period'] ?? '',
 				'period_start' => $assoc_args['period-start'] ?? '',
 				'period_end'   => $assoc_args['period-end'] ?? '',
 				'import_batch' => $assoc_args['batch'] ?? '',
-				'hostname'     => $assoc_args['hostname'] ?? 'extrachill.com',
-				'dry_run'      => isset( $assoc_args['dry-run'] ),
+				'blog_id'      => (int) ( $assoc_args['blog-id'] ?? 0 ),
+				'hostname'     => $assoc_args['hostname'] ?? '',
+				'cohort'       => $assoc_args['cohort'] ?? 'resolved',
+				'min_views'    => (int) ( $assoc_args['min-views'] ?? 0 ),
+				'sort_by'      => $assoc_args['sort-by'] ?? 'derived_rpm',
+				'order'        => $assoc_args['order'] ?? 'desc',
+				'limit'        => (int) ( $assoc_args['limit'] ?? 50 ),
 			)
 		);
+		$this->assert_success( $result, 'Revenue pages query failed.' );
 
-		if ( empty( $result['success'] ) ) {
-			WP_CLI::error( $result['error'] ?? 'CSV import failed.' );
+		$format = $assoc_args['format'] ?? 'table';
+		if ( 'table' !== $format ) {
+			WP_CLI::print_value( $result, array( 'format' => $format ) );
+			return;
 		}
 
-		$dry = ! empty( $result['dry_run'] );
-		WP_CLI::log( sprintf( 'Batch: %s · period bucket: %s%s', $result['batch'], $result['period'] ?? 'all-time', $dry ? ' (DRY RUN — nothing written)' : '' ) );
-		WP_CLI::log(
-			sprintf(
-				'Parsed %d rows · resolved %d to posts · %d unresolved · imported %d',
-				(int) $result['rows'],
-				(int) $result['resolved'],
-				(int) $result['unresolved'],
-				(int) $result['imported']
-			)
-		);
-
-		if ( ! empty( $result['samples'] ) ) {
-			WP_CLI::log( '' );
-			WP_CLI::log( 'Sample rows:' );
-			Utils\format_items( 'table', $result['samples'], array( 'slug', 'post_id', 'revenue', 'views' ) );
-		}
-
-		if ( (int) $result['unresolved'] > 0 ) {
-			WP_CLI::log( '' );
-			WP_CLI::log( 'Note: unresolved rows (often legacy .html ghost pages) are still stored and roll up under legacy-html/uncategorized.' );
-		}
-
-		if ( ! $dry ) {
-			WP_CLI::success( 'Import complete. Roll up with: wp extrachill analytics revenue rollup' );
-		}
+		WP_CLI::log( sprintf( 'Content Revenue Pages - %s', $result['window'] ?? '' ) );
+		Utils\format_items( 'table', (array) ( $result['pages'] ?? array() ), $this->page_fields() );
 	}
 
 	/**
-	 * Roll up imported revenue by content format or category.
-	 *
-	 * Wraps the extrachill/get-content-revenue ability. Reports pages, views,
-	 * revenue, RPM and $/page per bucket, sorted by $/page (the honest "worth
-	 * producing" metric — RPM alone misleads on low volume). Pass a window
-	 * (--period-start/--period-end) for the earning-NOW lens versus the default
-	 * lifetime-accumulated view.
+	 * Roll up ability-provided revenue metrics by format or category.
 	 *
 	 * ## OPTIONS
 	 *
 	 * [--group-by=<axis>]
-	 * : Rollup axis.
-	 * ---
-	 * default: format
-	 * options:
-	 *   - format
-	 *   - category
-	 *   - both
-	 * ---
-	 *
+	 * : format, category, or both.
 	 * [--period=<period>]
-	 * : Scope the rollup to one time bucket (e.g. 2026-05, or all-time). Empty = every bucket combined.
-	 *
 	 * [--period-start=<date>]
-	 * : Window start (Y-m-d). With --period-end, restricts to snapshots for that window (recent lens).
-	 *
 	 * [--period-end=<date>]
-	 * : Window end (Y-m-d).
-	 *
 	 * [--batch=<label>]
-	 * : Restrict to one import batch so multiple imports are never double-counted.
-	 *
 	 * [--hostname=<host>]
-	 * : Hostname for resolving any still-unresolved slugs.
-	 * ---
-	 * default: extrachill.com
-	 * ---
-	 *
 	 * [--limit=<n>]
-	 * : Max buckets to show per axis.
-	 * ---
-	 * default: 50
-	 * ---
-	 *
 	 * [--format=<format>]
-	 * : Output format.
-	 * ---
-	 * default: table
-	 * options:
-	 *   - table
-	 *   - json
-	 *   - csv
-	 * ---
-	 *
-	 * ## EXAMPLES
-	 *
-	 *     wp extrachill analytics revenue rollup
-	 *     wp extrachill analytics revenue rollup --group-by=category
-	 *     wp extrachill analytics revenue rollup --period=2026-05 --group-by=format
-	 *     wp extrachill analytics revenue rollup --group-by=both --format=json
+	 * : table, json, or csv.
 	 *
 	 * @subcommand rollup
 	 * @when after_wp_load
 	 */
 	public function rollup( $args, $assoc_args ) {
-		$ability = wp_get_ability( 'extrachill/get-content-revenue' );
-		if ( ! $ability ) {
-			WP_CLI::error( 'extrachill/get-content-revenue ability not found. Is Extra Chill Analytics active and up to date?' );
-		}
-
-		$limit  = max( 1, (int) ( $assoc_args['limit'] ?? 50 ) );
-		$format = $assoc_args['format'] ?? 'table';
-
-		$result = $ability->execute(
+		$ability = $this->ability( 'extrachill/get-content-revenue', 'Extra Chill Analytics' );
+		$result  = $ability->execute(
 			array(
 				'group_by'     => $assoc_args['group-by'] ?? 'format',
 				'period'       => $assoc_args['period'] ?? '',
@@ -459,229 +203,159 @@ class RevenueCommand {
 				'hostname'     => $assoc_args['hostname'] ?? 'extrachill.com',
 			)
 		);
+		$this->assert_success( $result, 'Revenue rollup failed.' );
 
-		if ( is_wp_error( $result ) ) {
-			WP_CLI::error( $result->get_error_message() );
-		}
-
-		if ( empty( $result['success'] ) ) {
-			WP_CLI::error( $result['caveat'] ?? ( $result['error'] ?? 'Revenue rollup failed.' ) );
-		}
-
+		$format = $assoc_args['format'] ?? 'table';
 		if ( 'table' !== $format ) {
 			WP_CLI::print_value( $result, array( 'format' => $format ) );
 			return;
 		}
 
-		WP_CLI::log( sprintf( 'Content Revenue Lens — %s', $result['window'] ?? '' ) );
-		$totals = $result['totals'] ?? array();
-		WP_CLI::log(
-			sprintf(
-				'Totals: %d pages · %s views · $%s revenue · $%s/page · $%s RPM',
-				(int) ( $totals['pages'] ?? 0 ),
-				number_format( (int) ( $totals['views'] ?? 0 ) ),
-				number_format( (float) ( $totals['revenue'] ?? 0 ), 2 ),
-				number_format( (float) ( $totals['dollars_per_page'] ?? 0 ), 2 ),
-				number_format( (float) ( $totals['rpm'] ?? 0 ), 2 )
-			)
-		);
-		WP_CLI::log( str_repeat( '─', 78 ) );
-
-		$rollups = $result['rollups'] ?? array();
-		if ( empty( $rollups ) ) {
-			WP_CLI::log( $result['caveat'] ?? 'No revenue data for this window.' );
-			return;
+		$limit = max( 1, (int) ( $assoc_args['limit'] ?? 50 ) );
+		foreach ( (array) ( $result['rollups'] ?? array() ) as $axis => $buckets ) {
+			WP_CLI::log( 'by_format' === $axis ? 'By content format:' : 'By category:' );
+			Utils\format_items( 'table', array_slice( $buckets, 0, $limit ), array( 'bucket', 'pages', 'views', 'revenue', 'dollars_per_page', 'rpm' ) );
 		}
-
-		foreach ( $rollups as $axis => $buckets ) {
-			$label = 'by_format' === $axis ? 'By content format' : 'By category';
-			WP_CLI::log( '' );
-			WP_CLI::log( $label . ' (sorted by $/page — the honest "worth producing" metric):' );
-			WP_CLI::log( '' );
-
-			$rows = array_map( array( $this, 'row' ), array_slice( $buckets, 0, $limit ) );
-			Utils\format_items( 'table', $rows, array( 'bucket', 'pages', 'views', 'revenue', 'dollars_per_page', 'rpm' ) );
-		}
-
-		WP_CLI::log( '' );
-		WP_CLI::log( '$/page = revenue / pages — RPM alone misleads (high RPM on tiny volume = pennies).' );
-		WP_CLI::log( 'High LIFETIME revenue can just mean a page is OLD; pass --period-start/--period-end for earning-NOW.' );
-		WP_CLI::log( 'Revenue is Mediavine-imported (the only source of ad income) — never estimated.' );
 	}
 
 	/**
-	 * Show the revenue ARC — revenue per time bucket, month-over-month.
-	 *
-	 * The first-class time-series view. Sums each imported period (one monthly
-	 * Mediavine export = one point) chronologically so you can see the revenue
-	 * arc and the HCU cliff IN DOLLARS, with a month-over-month delta per point.
-	 * Requires DATE-RANGED monthly exports imported with --period=YYYY-MM; the
-	 * flat lifetime file is a single cumulative "all-time" total (time-blind) and
-	 * is excluded by default.
+	 * Show the ability-provided revenue time series.
 	 *
 	 * ## OPTIONS
 	 *
 	 * [--include-alltime]
-	 * : Also show the cumulative "all-time" flat-file bucket (a lifetime total, not a point on the arc).
-	 *
 	 * [--format=<format>]
-	 * : Output format.
-	 * ---
-	 * default: table
-	 * options:
-	 *   - table
-	 *   - json
-	 *   - csv
-	 * ---
-	 *
-	 * ## EXAMPLES
-	 *
-	 *     wp extrachill analytics revenue arc
-	 *     wp extrachill analytics revenue arc --include-alltime
-	 *     wp extrachill analytics revenue arc --format=json
+	 * : table, json, or csv.
 	 *
 	 * @subcommand arc
 	 * @when after_wp_load
 	 */
 	public function arc( $args, $assoc_args ) {
-		$ability = wp_get_ability( 'extrachill/get-content-revenue' );
-		if ( ! $ability ) {
-			WP_CLI::error( 'extrachill/get-content-revenue ability not found. Is Extra Chill Analytics active and up to date?' );
-		}
-
-		$format = $assoc_args['format'] ?? 'table';
-
-		$result = $ability->execute(
+		$ability = $this->ability( 'extrachill/get-content-revenue', 'Extra Chill Analytics' );
+		$result  = $ability->execute(
 			array(
 				'group_by'        => 'timeseries',
 				'include_alltime' => isset( $assoc_args['include-alltime'] ),
 			)
 		);
+		$this->assert_success( $result, 'Revenue arc failed.' );
 
-		if ( is_wp_error( $result ) ) {
-			WP_CLI::error( $result->get_error_message() );
-		}
-		if ( empty( $result['success'] ) ) {
-			WP_CLI::error( $result['caveat'] ?? ( $result['error'] ?? 'Revenue arc failed.' ) );
-		}
-
-		$series = (array) ( $result['series'] ?? array() );
-
+		$format = $assoc_args['format'] ?? 'table';
 		if ( 'table' !== $format ) {
 			WP_CLI::print_value( $result, array( 'format' => $format ) );
 			return;
 		}
 
-		if ( empty( $series ) ) {
-			WP_CLI::log( 'No per-period data yet. Import DATE-RANGED monthly exports with --period=YYYY-MM to build the arc:' );
-			WP_CLI::log( '  wp extrachill analytics revenue import /tmp/mv-2026-05.csv --period=2026-05' );
-			return;
-		}
-
-		WP_CLI::log( 'Revenue ARC — per-period (month-over-month). Each point = one imported monthly Mediavine export.' );
-		$peak   = $result['peak'] ?? array();
-		$totals = $result['totals'] ?? array();
-		WP_CLI::log(
-			sprintf(
-				'%d periods · $%s total · peak %s ($%s)',
-				(int) ( $totals['periods'] ?? 0 ),
-				number_format( (float) ( $totals['revenue'] ?? 0 ), 2 ),
-				$peak['period'] ?? '—',
-				number_format( (float) ( $peak['revenue'] ?? 0 ), 2 )
-			)
-		);
-		WP_CLI::log( str_repeat( '─', 78 ) );
-
-		$rows = array();
-		foreach ( $series as $p ) {
-			$mom    = $p['mom_delta'];
-			$rows[] = array(
-				'period'  => $p['period'] ?? '',
-				'pages'   => (int) ( $p['pages'] ?? 0 ),
-				'views'   => number_format( (int) ( $p['views'] ?? 0 ) ),
-				'revenue' => '$' . number_format( (float) ( $p['revenue'] ?? 0 ), 2 ),
-				'mom'     => ( null === $mom ) ? '—' : ( ( $mom >= 0 ? '+$' : '-$' ) . number_format( abs( (float) $mom ), 2 ) ),
-				'mom_pct' => ( null === $p['mom_pct'] ) ? '—' : ( ( (float) $p['mom_pct'] >= 0 ? '+' : '' ) . $p['mom_pct'] . '%' ),
-				'rpm'     => '$' . number_format( (float) ( $p['rpm'] ?? 0 ), 2 ),
-			);
-		}
-		Utils\format_items( 'table', $rows, array( 'period', 'pages', 'views', 'revenue', 'mom', 'mom_pct', 'rpm' ) );
-
-		WP_CLI::log( '' );
-		WP_CLI::log( 'The flat lifetime export is time-blind (no dates) and undercounts the 2022-2023 peak — export monthly CSVs for the true arc.' );
-		WP_CLI::log( 'Revenue is Mediavine-imported (the only source of ad income) — never estimated.' );
+		Utils\format_items( 'table', (array) ( $result['series'] ?? array() ), array( 'period', 'pages', 'views', 'revenue', 'mom_delta', 'mom_pct', 'rpm' ) );
 	}
 
 	/**
-	 * List imported revenue batches for the current blog.
-	 *
-	 * Shows each (batch, period) snapshot set with its row count and totals so
-	 * you can pick a --batch for rollup and avoid double-counting overlapping
-	 * imports.
+	 * Show structured integrity diagnostics for the revenue store.
 	 *
 	 * ## OPTIONS
 	 *
+	 * [--period=<period>]
+	 * [--period-start=<date>]
+	 * [--period-end=<date>]
+	 * [--batch=<label>]
+	 * [--blog-id=<id>]
+	 * [--hostname=<host>]
 	 * [--format=<format>]
-	 * : Output format.
-	 * ---
-	 * default: table
-	 * options:
-	 *   - table
-	 *   - json
-	 *   - csv
-	 * ---
+	 * : table, json, or csv.
 	 *
-	 * ## EXAMPLES
-	 *
-	 *     wp extrachill analytics revenue batches
-	 *
-	 * @subcommand batches
+	 * @subcommand diagnose
 	 * @when after_wp_load
 	 */
-	public function batches( $args, $assoc_args ) {
-		if ( ! function_exists( 'extrachill_analytics_revenue_list_batches' ) ) {
-			WP_CLI::error( 'extrachill-analytics revenue store not available. Is Extra Chill Analytics active and up to date?' );
+	public function diagnose( $args, $assoc_args ) {
+		$ability = $this->ability( 'extrachill/get-content-revenue-diagnostics', 'Extra Chill Analytics' );
+		$result  = $ability->execute(
+			array(
+				'period'       => $assoc_args['period'] ?? '',
+				'period_start' => $assoc_args['period-start'] ?? '',
+				'period_end'   => $assoc_args['period-end'] ?? '',
+				'import_batch' => $assoc_args['batch'] ?? '',
+				'blog_id'      => (int) ( $assoc_args['blog-id'] ?? 0 ),
+				'hostname'     => $assoc_args['hostname'] ?? '',
+			)
+		);
+		$this->assert_success( $result, 'Revenue diagnostics failed.' );
+
+		$format = $assoc_args['format'] ?? 'table';
+		if ( 'table' === $format ) {
+			WP_CLI::log( sprintf( 'Content Revenue Diagnostics - %s - %s', $result['window'] ?? '', strtoupper( $result['overall_status'] ?? 'fail' ) ) );
+			Utils\format_items( 'table', (array) ( $result['checks'] ?? array() ), array( 'check', 'status', 'evidence', 'totals' ) );
+		} else {
+			WP_CLI::print_value( $result, array( 'format' => $format ) );
 		}
 
-		$format  = $assoc_args['format'] ?? 'table';
-		$batches = extrachill_analytics_revenue_list_batches();
-
-		if ( empty( $batches ) ) {
-			WP_CLI::log( 'No revenue batches imported yet. Import one: wp extrachill analytics revenue import <csv>' );
-			return;
+		if ( 'fail' === ( $result['overall_status'] ?? 'fail' ) ) {
+			WP_CLI::error( 'Revenue diagnostics reported failures.' );
 		}
-
-		$rows = array();
-		foreach ( $batches as $b ) {
-			$rows[] = array(
-				'batch'        => $b->import_batch,
-				'period'       => $b->period_label ?? 'all-time',
-				'period_start' => $b->period_start ?? '—',
-				'period_end'   => $b->period_end ?? '—',
-				'pages'        => (int) $b->rows_count,
-				'views'        => (int) $b->views,
-				'revenue'      => number_format( (float) $b->revenue, 2 ),
-				'imported_at'  => $b->imported_at,
-			);
-		}
-
-		Utils\format_items( $format, $rows, array( 'batch', 'period', 'period_start', 'period_end', 'pages', 'views', 'revenue', 'imported_at' ) );
 	}
 
-	/**
-	 * Shape one rollup bucket row for display.
-	 *
-	 * @param array $b Bucket row from the ability.
-	 * @return array<string, mixed>
-	 */
-	private function row( array $b ) {
-		return array(
-			'bucket'           => $b['bucket'] ?? '',
-			'pages'            => (int) ( $b['pages'] ?? 0 ),
-			'views'            => number_format( (int) ( $b['views'] ?? 0 ) ),
-			'revenue'          => '$' . number_format( (float) ( $b['revenue'] ?? 0 ), 2 ),
-			'dollars_per_page' => '$' . number_format( (float) ( $b['dollars_per_page'] ?? 0 ), 2 ),
-			'rpm'              => '$' . number_format( (float) ( $b['rpm'] ?? 0 ), 2 ),
+	private function ability( $name, $owner ) {
+		$ability = wp_get_ability( $name );
+		if ( ! $ability ) {
+			WP_CLI::error( sprintf( '%s ability not found. Is %s active and up to date?', $name, $owner ) );
+		}
+		return $ability;
+	}
+
+	private function fetch_periods( $assoc_args ) {
+		if ( isset( $assoc_args['periods'] ) ) {
+			$periods = json_decode( (string) $assoc_args['periods'], true );
+			if ( ! is_array( $periods ) || empty( $periods ) ) {
+				WP_CLI::error( '--periods must be a non-empty JSON array of {period, start_date, end_date} objects.' );
+			}
+			return $periods;
+		}
+
+		$period = array( 'period' => $assoc_args['period'] ?? '', 'start_date' => $assoc_args['start'] ?? '', 'end_date' => $assoc_args['end'] ?? '' );
+		if ( '' === $period['period'] || '' === $period['start_date'] || '' === $period['end_date'] ) {
+			WP_CLI::error( '--start, --end, and --period are required unless --periods is provided.' );
+		}
+		return array( $period );
+	}
+
+	private function ingest_rows( $rows ) {
+		return array_map(
+			static function ( $row ) {
+				return array(
+					'slug'                     => $row['slug'] ?? '',
+					'views'                    => $row['views'] ?? 0,
+					'revenue'                  => $row['revenue'] ?? 0,
+					'rpm'                      => $row['rpm'] ?? 0,
+					'cpm'                      => $row['cpm'] ?? 0,
+					'viewability'              => $row['viewability'] ?? 0,
+					'fill_rate'                => $row['fillRate'] ?? 0,
+					'impressions_per_pageview' => $row['impressionsPerPageview'] ?? 0,
+				);
+			},
+			$rows
 		);
+	}
+
+	private function source_site( $summary, $report ) {
+		$provenance = (array) ( $summary['provenance'] ?? $report['provenance'] ?? array() );
+		$site       = (array) ( $provenance['site'] ?? array() );
+		return (string) ( $site['relay_id'] ?? $site['requested_id'] ?? '' );
+	}
+
+	private function report_date( $summary, $requested_key, $canonical_key ) {
+		$canonical = $summary['provenance']['period']['canonical'][ $canonical_key ] ?? '';
+		return '' !== $canonical ? str_replace( '/', '-', (string) $canonical ) : (string) ( $summary[ $requested_key ] ?? '' );
+	}
+
+	private function assert_success( $result, $fallback ) {
+		if ( is_wp_error( $result ) ) {
+			WP_CLI::error( $result->get_error_message() );
+		}
+		if ( empty( $result['success'] ) ) {
+			WP_CLI::error( $result['error'] ?? $fallback );
+		}
+	}
+
+	private function page_fields() {
+		return array( 'cohort', 'post_id', 'title', 'url', 'categories', 'format', 'route_family', 'views', 'revenue', 'derived_rpm', 'source_rpm', 'cpm', 'viewability', 'fill_rate', 'impressions_per_pageview', 'zero_views', 'benchmark_opportunity' );
 	}
 }

--- a/tests/RevenueCommandTest.php
+++ b/tests/RevenueCommandTest.php
@@ -1,0 +1,190 @@
+<?php
+/**
+ * Focused behavior tests for the ability-backed revenue CLI adapters.
+ */
+
+namespace {
+	define( 'ABSPATH', __DIR__ . '/' );
+
+	class RevenueCommandTestError extends \RuntimeException {}
+
+	class WP_CLI {
+		public static $messages = array();
+		public static $printed = array();
+
+		public static function error( $message ) {
+			throw new RevenueCommandTestError( $message );
+		}
+
+		public static function log( $message ) {
+			self::$messages[] = $message;
+		}
+
+		public static function warning( $message ) {
+			self::$messages[] = 'Warning: ' . $message;
+		}
+
+		public static function success( $message ) {
+			self::$messages[] = 'Success: ' . $message;
+		}
+
+		public static function print_value( $value, $args ) {
+			self::$printed[] = compact( 'value', 'args' );
+		}
+	}
+
+	class RevenueCommandTestAbility {
+		public $inputs = array();
+		public $result;
+
+		public function __construct( $result ) {
+			$this->result = $result;
+		}
+
+		public function execute( $input ) {
+			$this->inputs[] = $input;
+			return $this->result;
+		}
+	}
+
+	$revenue_command_test_abilities = array();
+
+	function wp_get_ability( $name ) {
+		global $revenue_command_test_abilities;
+		return $revenue_command_test_abilities[ $name ] ?? null;
+	}
+
+	function is_wp_error( $value ) {
+		return false;
+	}
+
+	function revenue_command_test_assert_same( $expected, $actual, $message ) {
+		if ( $expected !== $actual ) {
+			throw new \RuntimeException( $message . '\nExpected: ' . var_export( $expected, true ) . '\nActual: ' . var_export( $actual, true ) );
+		}
+	}
+
+	function revenue_command_test_assert_true( $actual, $message ) {
+		if ( ! $actual ) {
+			throw new \RuntimeException( $message );
+		}
+	}
+}
+
+namespace WP_CLI\Utils {
+	$revenue_command_test_formats = array();
+
+	function format_items( $format, $items, $fields ) {
+		global $revenue_command_test_formats;
+		$revenue_command_test_formats[] = compact( 'format', 'items', 'fields' );
+	}
+}
+
+namespace {
+	require_once dirname( __DIR__ ) . '/inc/Commands/Analytics/RevenueCommand.php';
+
+	use ExtraChill\CLI\Commands\Analytics\RevenueCommand;
+
+	global $revenue_command_test_abilities, $revenue_command_test_formats;
+
+	$report = new RevenueCommandTestAbility(
+		array(
+			'success'  => true,
+			'results'  => array(
+				array( 'slug' => '/one/', 'views' => 100, 'revenue' => 4.5, 'rpm' => 45, 'cpm' => 8, 'viewability' => 0.7, 'fillRate' => 0.8, 'impressionsPerPageview' => 2.1, 'period' => '2026-05' ),
+			),
+			'periods'  => array(
+				array(
+					'period'     => '2026-05',
+					'start_date' => '2026-05-01',
+					'end_date'   => '2026-05-31',
+					'provenance' => array(
+						'site'   => array( 'relay_id' => 'SW50ZXJuYWxTaXRlOjQy' ),
+						'period' => array( 'canonical' => array( 'start' => '2026/05/02', 'end' => '2026/05/30' ) ),
+					),
+				),
+			),
+		)
+	);
+	$ingest = new RevenueCommandTestAbility(
+		array(
+			'success'  => true,
+			'rows'     => 1,
+			'resolved' => 1,
+			'identity' => array( 'import_batch' => 'rev-mediavine-42-2026-05' ),
+		)
+	);
+	$revenue_command_test_abilities = array(
+		'datamachine/mediavine-reports' => $report,
+		'extrachill/ingest-revenue'     => $ingest,
+	);
+
+	$command = new RevenueCommand();
+	$command->fetch( array(), array( 'start' => '2026-05-01', 'end' => '2026-05-31', 'period' => '2026-05', 'site-id' => '42', 'dry-run' => true ) );
+	revenue_command_test_assert_same(
+		array( array( 'action' => 'backfill', 'periods' => array( array( 'period' => '2026-05', 'start_date' => '2026-05-01', 'end_date' => '2026-05-31' ) ), 'site_id' => '42' ) ),
+		$report->inputs,
+		'Fetch must request the documented Mediavine backfill contract.'
+	);
+	revenue_command_test_assert_same(
+		array( array(
+			'rows' => array( array( 'slug' => '/one/', 'views' => 100, 'revenue' => 4.5, 'rpm' => 45, 'cpm' => 8, 'viewability' => 0.7, 'fill_rate' => 0.8, 'impressions_per_pageview' => 2.1 ) ),
+			'hostname' => 'extrachill.com', 'source' => 'mediavine', 'source_site' => 'SW50ZXJuYWxTaXRlOjQy', 'period' => '2026-05', 'period_start' => '2026-05-02', 'period_end' => '2026-05-30', 'dry_run' => true,
+		) ),
+		$ingest->inputs,
+		'Fetch must hand source rows and report provenance to the ingestion ability for deterministic replacement.'
+	);
+	$command->fetch( array(), array( 'start' => '2026-05-01', 'end' => '2026-05-31', 'period' => '2026-05', 'site-id' => '42', 'dry-run' => true ) );
+	revenue_command_test_assert_same( $ingest->inputs[0], $ingest->inputs[1], 'Repeated fetches must invoke ingestion with the identical deterministic snapshot inputs.' );
+	$source = file_get_contents( dirname( __DIR__ ) . '/inc/Commands/Analytics/RevenueCommand.php' );
+	revenue_command_test_assert_true( false === strpos( $source, 'extrachill_analytics_revenue_import_csv' ), 'Revenue command must not call the legacy direct importer.' );
+	revenue_command_test_assert_true( false === strpos( $source, 'wp_tempnam' ), 'Revenue command must not serialize report rows to temporary CSV files.' );
+
+	$pages = new RevenueCommandTestAbility(
+		array(
+			'success' => true, 'window' => '2026-05',
+			'pages'   => array( array( 'cohort' => 'resolved', 'post_id' => 9, 'title' => 'A post', 'url' => 'https://example.com/a', 'categories' => array( 'news' ), 'format' => 'news', 'route_family' => '', 'views' => 100, 'revenue' => 4.5, 'derived_rpm' => 45, 'source_rpm' => 44, 'cpm' => 8, 'viewability' => 0.7, 'fill_rate' => 0.8, 'impressions_per_pageview' => 2.1, 'zero_views' => false, 'benchmark_opportunity' => true ) ),
+		)
+	);
+	$revenue_command_test_abilities['extrachill/get-content-revenue-pages'] = $pages;
+	$command->pages( array(), array( 'period' => '2026-05', 'cohort' => 'all', 'min-views' => 100, 'sort-by' => 'cpm', 'order' => 'asc', 'limit' => 5 ) );
+	revenue_command_test_assert_same(
+		array( array( 'period' => '2026-05', 'period_start' => '', 'period_end' => '', 'import_batch' => '', 'blog_id' => 0, 'hostname' => '', 'cohort' => 'all', 'min_views' => 100, 'sort_by' => 'cpm', 'order' => 'asc', 'limit' => 5 ) ),
+		$pages->inputs,
+		'Pages must forward the documented ability inputs without recomputation.'
+	);
+	revenue_command_test_assert_same( 'table', $revenue_command_test_formats[0]['format'], 'Pages defaults to table output.' );
+	revenue_command_test_assert_same( 45, $revenue_command_test_formats[0]['items'][0]['derived_rpm'], 'Pages table preserves ability-derived metrics.' );
+	$command->pages( array(), array( 'format' => 'json' ) );
+	revenue_command_test_assert_same( 'json', \WP_CLI::$printed[0]['args']['format'], 'Pages preserves JSON output.' );
+
+	$diagnostics = new RevenueCommandTestAbility(
+		array(
+			'success' => true, 'window' => 'all history', 'overall_status' => 'pass',
+			'checks'  => array( array( 'check' => 'freshness', 'status' => 'pass', 'evidence' => array( 'current' ), 'totals' => array( 'rows' => 1 ) ) ),
+		)
+	);
+	$revenue_command_test_abilities['extrachill/get-content-revenue-diagnostics'] = $diagnostics;
+	$command->diagnose( array(), array() );
+	$diagnostics->result['overall_status'] = 'warning';
+	$diagnostics->result['checks'][0]['status'] = 'warning';
+	$command->diagnose( array(), array() );
+	revenue_command_test_assert_same( 3, count( $revenue_command_test_formats ), 'Diagnostics pass and warning states must both remain successful.' );
+	$diagnostics->result['overall_status'] = 'fail';
+	try {
+		$command->diagnose( array(), array( 'format' => 'json' ) );
+		throw new \RuntimeException( 'Failing diagnostics did not exit nonzero.' );
+	} catch ( RevenueCommandTestError $error ) {
+		revenue_command_test_assert_same( 'Revenue diagnostics reported failures.', $error->getMessage(), 'Only the ability fail status must produce the diagnostics CLI error.' );
+	}
+
+	unset( $revenue_command_test_abilities['extrachill/get-content-revenue-pages'] );
+	try {
+		$command->pages( array(), array() );
+		throw new \RuntimeException( 'Missing pages ability did not terminate the command.' );
+	} catch ( RevenueCommandTestError $error ) {
+		revenue_command_test_assert_same( 'extrachill/get-content-revenue-pages ability not found. Is Extra Chill Analytics active and up to date?', $error->getMessage(), 'Missing ability errors must name the canonical owner.' );
+	}
+
+	fwrite( STDOUT, "RevenueCommand tests passed.\n" );
+}

--- a/tests/RevenueCommandTest.php
+++ b/tests/RevenueCommandTest.php
@@ -58,6 +58,10 @@ namespace {
 		return false;
 	}
 
+	function wp_json_encode( $value ) {
+		return json_encode( $value );
+	}
+
 	function revenue_command_test_assert_same( $expected, $actual, $message ) {
 		if ( $expected !== $actual ) {
 			throw new \RuntimeException( $message . '\nExpected: ' . var_export( $expected, true ) . '\nActual: ' . var_export( $actual, true ) );
@@ -129,13 +133,54 @@ namespace {
 	revenue_command_test_assert_same(
 		array( array(
 			'rows' => array( array( 'slug' => '/one/', 'views' => 100, 'revenue' => 4.5, 'rpm' => 45, 'cpm' => 8, 'viewability' => 0.7, 'fill_rate' => 0.8, 'impressions_per_pageview' => 2.1 ) ),
-			'hostname' => 'extrachill.com', 'source' => 'mediavine', 'source_site' => 'SW50ZXJuYWxTaXRlOjQy', 'period' => '2026-05', 'period_start' => '2026-05-02', 'period_end' => '2026-05-30', 'dry_run' => true,
+			'hostname' => 'extrachill.com', 'source' => 'mediavine', 'source_site' => 'SW50ZXJuYWxTaXRlOjQy', 'period' => '2026-05', 'period_start' => '2026-05-01', 'period_end' => '2026-05-31', 'mode' => 'replace', 'snapshot' => '', 'dry_run' => true,
 		) ),
 		$ingest->inputs,
 		'Fetch must hand source rows and report provenance to the ingestion ability for deterministic replacement.'
 	);
 	$command->fetch( array(), array( 'start' => '2026-05-01', 'end' => '2026-05-31', 'period' => '2026-05', 'site-id' => '42', 'dry-run' => true ) );
 	revenue_command_test_assert_same( $ingest->inputs[0], $ingest->inputs[1], 'Repeated fetches must invoke ingestion with the identical deterministic snapshot inputs.' );
+	$command->fetch( array(), array( 'start' => '2026-05-01', 'end' => '2026-05-31', 'period' => '2026-05', 'mode' => 'additive', 'snapshot' => 'manual-2026-05', 'dry-run' => true ) );
+	revenue_command_test_assert_same( 'additive', $ingest->inputs[2]['mode'], 'Additive mode must be forwarded to the ingestion ability.' );
+	revenue_command_test_assert_same( 'manual-2026-05', $ingest->inputs[2]['snapshot'], 'Explicit additive snapshots must be forwarded without CLI identity logic.' );
+	$report_calls_before_invalid = count( $report->inputs );
+	foreach ( array(
+		array( 'periods' => '[{"period":"","start_date":"2026-05-01","end_date":"2026-05-31"}]' ),
+		array( 'periods' => '[{"period":"2026-05","start_date":"2026-05-01","end_date":"2026-05-31"},{"period":"2026-05","start_date":"2026-06-01","end_date":"2026-06-30"}]' ),
+		array( 'periods' => '[{"period":"2026-05","start_date":"2026-02-30","end_date":"2026-05-31"}]' ),
+		array( 'start' => '2026-05-01', 'end' => '2026-05-31', 'period' => '2026-05', 'mode' => 'additive' ),
+	) as $invalid_args ) {
+		try {
+			$command->fetch( array(), $invalid_args );
+			throw new \RuntimeException( 'Invalid revenue fetch input did not terminate the command.' );
+		} catch ( RevenueCommandTestError $error ) {
+			// Each invalid input must be rejected before calling the source ability.
+		}
+	}
+	revenue_command_test_assert_same( $report_calls_before_invalid, count( $report->inputs ), 'Invalid periods and additive snapshots must be rejected before the source call.' );
+	$partial_report = new RevenueCommandTestAbility(
+		array(
+			'success' => true,
+			'results' => array( array( 'slug' => '/one/', 'period' => '2026-05' ) ),
+			'periods' => array( array( 'period' => '2026-05', 'start_date' => '2026-05-01', 'end_date' => '2026-05-31' ), array( 'period' => '2026-06', 'error' => 'Mediavine timeout' ) ),
+		)
+	);
+	$partial_ingest = new RevenueCommandTestAbility( array( 'success' => true ) );
+	$revenue_command_test_abilities['datamachine/mediavine-reports'] = $partial_report;
+	$revenue_command_test_abilities['extrachill/ingest-revenue']     = $partial_ingest;
+	try {
+		$command->fetch( array(), array( 'periods' => '[{"period":"2026-05","start_date":"2026-05-01","end_date":"2026-05-31"},{"period":"2026-06","start_date":"2026-06-01","end_date":"2026-06-30"}]' ) );
+		throw new \RuntimeException( 'Partial Mediavine failure did not terminate the command.' );
+	} catch ( RevenueCommandTestError $error ) {
+		revenue_command_test_assert_true( false !== strpos( $error->getMessage(), 'no revenue was ingested' ), 'Partial source failures must be explicit and nonzero.' );
+	}
+	revenue_command_test_assert_same( array(), $partial_ingest->inputs, 'A partial source failure must abort before any ingestion call.' );
+	$revenue_command_test_abilities['datamachine/mediavine-reports'] = $report;
+	$revenue_command_test_abilities['extrachill/ingest-revenue']     = $ingest;
+	$report->result['periods'][0]['provenance']['period']['canonical'] = array( 'start' => null, 'end' => null );
+	$command->fetch( array(), array( 'start' => '2026-05-01', 'end' => '2026-05-31', 'period' => '2026-05', 'dry-run' => true ) );
+	revenue_command_test_assert_same( '2026-05-01', $ingest->inputs[3]['period_start'], 'Null canonical start metadata must use the exact requested window start.' );
+	revenue_command_test_assert_same( '2026-05-31', $ingest->inputs[3]['period_end'], 'Null canonical end metadata must use the exact requested window end.' );
 	$source = file_get_contents( dirname( __DIR__ ) . '/inc/Commands/Analytics/RevenueCommand.php' );
 	revenue_command_test_assert_true( false === strpos( $source, 'extrachill_analytics_revenue_import_csv' ), 'Revenue command must not call the legacy direct importer.' );
 	revenue_command_test_assert_true( false === strpos( $source, 'wp_tempnam' ), 'Revenue command must not serialize report rows to temporary CSV files.' );
@@ -143,7 +188,7 @@ namespace {
 	$pages = new RevenueCommandTestAbility(
 		array(
 			'success' => true, 'window' => '2026-05',
-			'pages'   => array( array( 'cohort' => 'resolved', 'post_id' => 9, 'title' => 'A post', 'url' => 'https://example.com/a', 'categories' => array( 'news' ), 'format' => 'news', 'route_family' => '', 'views' => 100, 'revenue' => 4.5, 'derived_rpm' => 45, 'source_rpm' => 44, 'cpm' => 8, 'viewability' => 0.7, 'fill_rate' => 0.8, 'impressions_per_pageview' => 2.1, 'zero_views' => false, 'benchmark_opportunity' => true ) ),
+			'pages'   => array( array( 'cohort' => 'resolved', 'post_id' => 9, 'title' => 'A post', 'url' => 'https://example.com/a', 'categories' => array( 'news' ), 'format' => 'news', 'route_family' => '', 'views' => 100, 'revenue' => 4.5, 'dollars_per_page' => 4.5, 'derived_rpm' => 45, 'source_rpm' => 44, 'cpm' => 8, 'viewability' => 0.7, 'fill_rate' => 0.8, 'impressions_per_pageview' => 2.1, 'benchmark_score' => 1.2, 'zero_views' => false, 'benchmark_opportunity' => true ) ),
 		)
 	);
 	$revenue_command_test_abilities['extrachill/get-content-revenue-pages'] = $pages;
@@ -155,6 +200,11 @@ namespace {
 	);
 	revenue_command_test_assert_same( 'table', $revenue_command_test_formats[0]['format'], 'Pages defaults to table output.' );
 	revenue_command_test_assert_same( 45, $revenue_command_test_formats[0]['items'][0]['derived_rpm'], 'Pages table preserves ability-derived metrics.' );
+	revenue_command_test_assert_true( in_array( 'dollars_per_page', $revenue_command_test_formats[0]['fields'], true ), 'Pages table must expose dollars_per_page for supported sorting.' );
+	revenue_command_test_assert_true( in_array( 'benchmark_score', $revenue_command_test_formats[0]['fields'], true ), 'Pages table must expose benchmark_score for supported sorting.' );
+	$command->pages( array(), array( 'format' => 'csv' ) );
+	revenue_command_test_assert_same( 'csv', $revenue_command_test_formats[1]['format'], 'Pages CSV must format page rows rather than the response envelope.' );
+	revenue_command_test_assert_same( 9, $revenue_command_test_formats[1]['items'][0]['post_id'], 'Pages CSV must contain the ability page rows.' );
 	$command->pages( array(), array( 'format' => 'json' ) );
 	revenue_command_test_assert_same( 'json', \WP_CLI::$printed[0]['args']['format'], 'Pages preserves JSON output.' );
 
@@ -169,7 +219,11 @@ namespace {
 	$diagnostics->result['overall_status'] = 'warning';
 	$diagnostics->result['checks'][0]['status'] = 'warning';
 	$command->diagnose( array(), array() );
-	revenue_command_test_assert_same( 3, count( $revenue_command_test_formats ), 'Diagnostics pass and warning states must both remain successful.' );
+	revenue_command_test_assert_same( 4, count( $revenue_command_test_formats ), 'Diagnostics pass and warning states must both remain successful.' );
+	$command->diagnose( array(), array( 'format' => 'csv' ) );
+	revenue_command_test_assert_same( 'csv', $revenue_command_test_formats[4]['format'], 'Diagnostics CSV must format individual check rows.' );
+	revenue_command_test_assert_same( '["current"]', $revenue_command_test_formats[4]['items'][0]['evidence'], 'Diagnostics CSV must flatten evidence for tabular output.' );
+	revenue_command_test_assert_same( '{"rows":1}', $revenue_command_test_formats[4]['items'][0]['totals'], 'Diagnostics CSV must flatten totals for tabular output.' );
 	$diagnostics->result['overall_status'] = 'fail';
 	try {
 		$command->diagnose( array(), array( 'format' => 'json' ) );
@@ -177,6 +231,21 @@ namespace {
 	} catch ( RevenueCommandTestError $error ) {
 		revenue_command_test_assert_same( 'Revenue diagnostics reported failures.', $error->getMessage(), 'Only the ability fail status must produce the diagnostics CLI error.' );
 	}
+
+	$revenue = new RevenueCommandTestAbility(
+		array(
+			'success' => true,
+			'rollups' => array( 'by_format' => array( array( 'bucket' => 'news', 'pages' => 1, 'views' => 100, 'revenue' => 4.5, 'dollars_per_page' => 4.5, 'rpm' => 45 ) ) ),
+			'series'  => array( array( 'period' => '2026-05', 'pages' => 1, 'views' => 100, 'revenue' => 4.5, 'mom_delta' => 0, 'mom_pct' => 0, 'rpm' => 45 ) ),
+		)
+	);
+	$revenue_command_test_abilities['extrachill/get-content-revenue'] = $revenue;
+	$command->rollup( array(), array( 'format' => 'csv' ) );
+	revenue_command_test_assert_same( 'csv', $revenue_command_test_formats[5]['format'], 'Rollup CSV must format bucket rows.' );
+	revenue_command_test_assert_same( 'news', $revenue_command_test_formats[5]['items'][0]['bucket'], 'Rollup CSV must contain returned bucket rows.' );
+	$command->arc( array(), array( 'format' => 'csv' ) );
+	revenue_command_test_assert_same( 'csv', $revenue_command_test_formats[6]['format'], 'Arc CSV must format series rows.' );
+	revenue_command_test_assert_same( '2026-05', $revenue_command_test_formats[6]['items'][0]['period'], 'Arc CSV must contain returned series rows.' );
 
 	unset( $revenue_command_test_abilities['extrachill/get-content-revenue-pages'] );
 	try {


### PR DESCRIPTION
## Summary
- replace direct Mediavine CSV/temp-file ingestion with the Mediavine reports and deterministic revenue-ingestion abilities
- add page-level revenue and diagnostic CLI adapters with row-based table, JSON, and CSV output
- harden fetch validation, additive snapshot forwarding, canonical-window fallback, and all-or-nothing source failure handling

## Architecture
The CLI performs only argument validation, ability invocation, source-row normalization, and output formatting. Snapshot identity, route resolution, persistence, metrics, sorting, and diagnostics remain owned by the merged abilities.

## Compatibility
The operator explicitly approved removal of legacy `revenue import` and `revenue batches` under the nuke-legacy-support policy. They are intentionally not restored because they bypass the ability-owned ingestion contract. Existing ability-backed `rollup` and `arc` commands remain available.

## Tests
- `php tests/QRCodeCommandTest.php`
- `php tests/CrosslinkTargetsCommandTest.php`
- `php tests/UserLocalSceneCommandTest.php`
- `php tests/RevenueCommandTest.php`
- `php -l inc/Commands/Analytics/RevenueCommand.php`
- `php -l tests/RevenueCommandTest.php`
- `git diff --check`

PHPCS is not installed in this worktree. Homeboy test/lint was not forced because the VPS is under high load and no eligible offload runner is configured.

Fixes #92
Fixes #93