### PR TITLE
fix: accept documented revenue filters

### DIFF
--- a/homeboy.json
+++ b/homeboy.json
@@ -11,7 +11,8 @@
       "php tests/QRCodeCommandTest.php",
       "php tests/CrosslinkTargetsCommandTest.php",
       "php tests/UserLocalSceneCommandTest.php",
-      "php tests/RevenueCommandTest.php"
+      "php tests/RevenueCommandTest.php",
+      "php tests/RevenueCommandRuntimeTest.php"
     ]
   },
   "version_targets": [

--- a/inc/Commands/Analytics/RevenueCommand.php
+++ b/inc/Commands/Analytics/RevenueCommand.php
@@ -19,6 +19,8 @@ class RevenueCommand {
 	/**
 	 * Fetch Mediavine period reports and replace their deterministic snapshots.
 	 *
+	 * @synopsis [--start=<date>] [--end=<date>] [--period=<period>] [--periods=<json>] [--site-id=<id>] [--hostname=<host>] [--mode=<mode>] [--snapshot=<label>] [--dry-run]
+	 *
 	 * ## OPTIONS
 	 *
 	 * [--start=<date>]
@@ -145,6 +147,8 @@ class RevenueCommand {
 	/**
 	 * List page-level Mediavine delivery metrics.
 	 *
+	 * @synopsis [--period=<period>] [--period-start=<date>] [--period-end=<date>] [--batch=<label>] [--blog-id=<id>] [--hostname=<host>] [--cohort=<cohort>] [--min-views=<n>] [--sort-by=<metric>] [--order=<direction>] [--limit=<n>] [--format=<format>]
+	 *
 	 * ## OPTIONS
 	 *
 	 * [--period=<period>]
@@ -204,6 +208,8 @@ class RevenueCommand {
 	/**
 	 * Roll up ability-provided revenue metrics by format or category.
 	 *
+	 * @synopsis [--group-by=<axis>] [--period=<period>] [--period-start=<date>] [--period-end=<date>] [--batch=<label>] [--hostname=<host>] [--limit=<n>] [--format=<format>]
+	 *
 	 * ## OPTIONS
 	 *
 	 * [--group-by=<axis>]
@@ -254,6 +260,8 @@ class RevenueCommand {
 	/**
 	 * Show the ability-provided revenue time series.
 	 *
+	 * @synopsis [--include-alltime] [--format=<format>]
+	 *
 	 * ## OPTIONS
 	 *
 	 * [--include-alltime]
@@ -284,6 +292,8 @@ class RevenueCommand {
 
 	/**
 	 * Show structured integrity diagnostics for the revenue store.
+	 *
+	 * @synopsis [--period=<period>] [--period-start=<date>] [--period-end=<date>] [--batch=<label>] [--blog-id=<id>] [--hostname=<host>] [--format=<format>]
 	 *
 	 * ## OPTIONS
 	 *

--- a/tests/RevenueCommandRuntimeBootstrap.php
+++ b/tests/RevenueCommandRuntimeBootstrap.php
@@ -1,0 +1,11 @@
+<?php
+/**
+ * Registers the worktree plugin after WordPress has loaded.
+ */
+
+WP_CLI::add_hook(
+	'after_wp_load',
+	static function () {
+		require dirname( __DIR__ ) . '/extrachill-cli.php';
+	}
+);

--- a/tests/RevenueCommandRuntimeTest.php
+++ b/tests/RevenueCommandRuntimeTest.php
@@ -3,19 +3,28 @@
  * Exercises revenue argument validation through a real WP-CLI dispatcher.
  */
 
-$wp_path = getenv( 'WP_CLI_RUNTIME_PATH' );
-if ( false === $wp_path || '' === $wp_path ) {
-	fwrite( STDOUT, "RevenueCommand runtime test skipped: WP_CLI_RUNTIME_PATH is not set.\n" );
-	exit( 0 );
+$wp_path    = getenv( 'WP_CLI_RUNTIME_PATH' );
+$candidates = array_filter( array( $wp_path, '/var/www/extrachill.com', '/var/www/html', '/wordpress' ) );
+$wp_path    = '';
+foreach ( $candidates as $candidate ) {
+	$check = sprintf( 'wp --path=%s --allow-root --skip-plugins --skip-themes core is-installed 2>/dev/null', escapeshellarg( $candidate ) );
+	exec( $check, $ignored, $status );
+	if ( 0 === $status ) {
+		$wp_path = $candidate;
+		break;
+	}
+}
+if ( '' === $wp_path ) {
+	throw new RuntimeException( 'RevenueCommand runtime tests require an installed WordPress path.' );
 }
 
 $bootstrap = __DIR__ . '/RevenueCommandRuntimeBootstrap.php';
 $commands  = array(
-	'fetch --hostname=extrachill.com --dry-run',
-	'pages --hostname=extrachill.com --min-views=1000 --limit=25',
-	'rollup --hostname=extrachill.com --limit=100',
+	'fetch --start=2026-05-01 --end=2026-05-31 --period=2026-05 --periods=\'[{"period":"2026-05","start_date":"2026-05-01","end_date":"2026-05-31"}]\' --site-id=42 --hostname=extrachill.com --mode=additive --snapshot=test --dry-run',
+	'pages --period=2026-05 --period-start=2026-05-01 --period-end=2026-05-31 --batch=test --blog-id=1 --hostname=extrachill.com --cohort=resolved --min-views=1000 --sort-by=revenue --order=desc --limit=25 --format=json',
+	'rollup --group-by=both --period=2026-05 --period-start=2026-05-01 --period-end=2026-05-31 --batch=test --hostname=extrachill.com --limit=100 --format=json',
 	'arc --include-alltime --format=json',
-	'diagnose --hostname=extrachill.com --format=json',
+	'diagnose --period=2026-05 --period-start=2026-05-01 --period-end=2026-05-31 --batch=test --blog-id=1 --hostname=extrachill.com --format=json',
 );
 
 foreach ( $commands as $command ) {

--- a/tests/RevenueCommandRuntimeTest.php
+++ b/tests/RevenueCommandRuntimeTest.php
@@ -1,0 +1,42 @@
+<?php
+/**
+ * Exercises revenue argument validation through a real WP-CLI dispatcher.
+ */
+
+$wp_path = getenv( 'WP_CLI_RUNTIME_PATH' );
+if ( false === $wp_path || '' === $wp_path ) {
+	fwrite( STDOUT, "RevenueCommand runtime test skipped: WP_CLI_RUNTIME_PATH is not set.\n" );
+	exit( 0 );
+}
+
+$bootstrap = __DIR__ . '/RevenueCommandRuntimeBootstrap.php';
+$commands  = array(
+	'fetch --hostname=extrachill.com --dry-run',
+	'pages --hostname=extrachill.com --min-views=1000 --limit=25',
+	'rollup --hostname=extrachill.com --limit=100',
+	'arc --include-alltime --format=json',
+	'diagnose --hostname=extrachill.com --format=json',
+);
+
+foreach ( $commands as $command ) {
+	$runtime_command = sprintf(
+		'wp --path=%s --allow-root --skip-plugins --require=%s extrachill analytics revenue %s 2>&1',
+		escapeshellarg( $wp_path ),
+		escapeshellarg( $bootstrap ),
+		$command
+	);
+	exec( $runtime_command, $output, $exit_code );
+	$output = implode( "\n", $output );
+
+	if ( false !== strpos( $output, 'Parameter errors:' ) || false !== strpos( $output, 'unknown --' ) ) {
+		throw new RuntimeException( sprintf( 'WP-CLI rejected documented revenue options for "%s": %s', $command, $output ) );
+	}
+	if ( false === strpos( $output, 'ability not found' ) ) {
+		throw new RuntimeException( sprintf( 'Revenue command "%s" did not reach its Ability boundary: %s', $command, $output ) );
+	}
+	if ( 0 === $exit_code ) {
+		throw new RuntimeException( sprintf( 'Revenue command "%s" unexpectedly succeeded without its Ability.', $command ) );
+	}
+}
+
+fwrite( STDOUT, "RevenueCommand runtime tests passed.\n" );

--- a/tests/RevenueCommandTest.php
+++ b/tests/RevenueCommandTest.php
@@ -74,20 +74,6 @@ namespace {
 		}
 	}
 
-	function revenue_command_test_assert_synopsis_accepts_documented_options( $method, $args ) {
-		$reflection = new \ReflectionMethod( \ExtraChill\CLI\Commands\Analytics\RevenueCommand::class, $method );
-		$docblock   = $reflection->getDocComment();
-		preg_match( '/@synopsis\s+(.+)/', $docblock, $synopsis_match );
-		preg_match_all( '/\[--([a-z-]+)(?:=<[^>]+>)?\]/', $docblock, $documented_match );
-		preg_match_all( '/\[--([a-z-]+)(?:=<[^>]+>)?\]/', $synopsis_match[1] ?? '', $synopsis_match );
-
-		$documented = array_unique( $documented_match[1] );
-		$synopsis   = array_unique( $synopsis_match[1] );
-		$unknown    = array_diff( array_keys( $args ), $synopsis );
-
-		revenue_command_test_assert_same( array(), array_diff( $documented, $synopsis ), sprintf( '%s synopsis must include every documented option.', $method ) );
-		revenue_command_test_assert_same( array(), $unknown, sprintf( '%s synopsis rejected documented options before command execution.', $method ) );
-	}
 }
 
 namespace WP_CLI\Utils {
@@ -139,11 +125,6 @@ namespace {
 	);
 
 	$command = new RevenueCommand();
-	revenue_command_test_assert_synopsis_accepts_documented_options( 'fetch', array( 'start' => '2026-05-01', 'end' => '2026-05-31', 'period' => '2026-05', 'periods' => '[]', 'site-id' => '42', 'hostname' => 'extrachill.com', 'mode' => 'replace', 'snapshot' => 'manual', 'dry-run' => true ) );
-	revenue_command_test_assert_synopsis_accepts_documented_options( 'pages', array( 'period' => '2026-05', 'period-start' => '2026-05-01', 'period-end' => '2026-05-31', 'batch' => 'rev-mediavine-42-2026-05', 'blog-id' => '1', 'hostname' => 'extrachill.com', 'cohort' => 'resolved', 'min-views' => '1000', 'sort-by' => 'views', 'order' => 'desc', 'limit' => '25', 'format' => 'json' ) );
-	revenue_command_test_assert_synopsis_accepts_documented_options( 'rollup', array( 'group-by' => 'format', 'period' => '2026-05', 'period-start' => '2026-05-01', 'period-end' => '2026-05-31', 'batch' => 'rev-mediavine-42-2026-05', 'hostname' => 'extrachill.com', 'limit' => '100', 'format' => 'json' ) );
-	revenue_command_test_assert_synopsis_accepts_documented_options( 'arc', array( 'include-alltime' => true, 'format' => 'json' ) );
-	revenue_command_test_assert_synopsis_accepts_documented_options( 'diagnose', array( 'period' => '2026-05', 'period-start' => '2026-05-01', 'period-end' => '2026-05-31', 'batch' => 'rev-mediavine-42-2026-05', 'blog-id' => '1', 'hostname' => 'extrachill.com', 'format' => 'json' ) );
 	$command->fetch( array(), array( 'start' => '2026-05-01', 'end' => '2026-05-31', 'period' => '2026-05', 'site-id' => '42', 'dry-run' => true ) );
 	revenue_command_test_assert_same(
 		array( array( 'action' => 'backfill', 'periods' => array( array( 'period' => '2026-05', 'start_date' => '2026-05-01', 'end_date' => '2026-05-31' ) ), 'site_id' => '42' ) ),

--- a/tests/RevenueCommandTest.php
+++ b/tests/RevenueCommandTest.php
@@ -73,6 +73,21 @@ namespace {
 			throw new \RuntimeException( $message );
 		}
 	}
+
+	function revenue_command_test_assert_synopsis_accepts_documented_options( $method, $args ) {
+		$reflection = new \ReflectionMethod( \ExtraChill\CLI\Commands\Analytics\RevenueCommand::class, $method );
+		$docblock   = $reflection->getDocComment();
+		preg_match( '/@synopsis\s+(.+)/', $docblock, $synopsis_match );
+		preg_match_all( '/\[--([a-z-]+)(?:=<[^>]+>)?\]/', $docblock, $documented_match );
+		preg_match_all( '/\[--([a-z-]+)(?:=<[^>]+>)?\]/', $synopsis_match[1] ?? '', $synopsis_match );
+
+		$documented = array_unique( $documented_match[1] );
+		$synopsis   = array_unique( $synopsis_match[1] );
+		$unknown    = array_diff( array_keys( $args ), $synopsis );
+
+		revenue_command_test_assert_same( array(), array_diff( $documented, $synopsis ), sprintf( '%s synopsis must include every documented option.', $method ) );
+		revenue_command_test_assert_same( array(), $unknown, sprintf( '%s synopsis rejected documented options before command execution.', $method ) );
+	}
 }
 
 namespace WP_CLI\Utils {
@@ -124,6 +139,11 @@ namespace {
 	);
 
 	$command = new RevenueCommand();
+	revenue_command_test_assert_synopsis_accepts_documented_options( 'fetch', array( 'start' => '2026-05-01', 'end' => '2026-05-31', 'period' => '2026-05', 'periods' => '[]', 'site-id' => '42', 'hostname' => 'extrachill.com', 'mode' => 'replace', 'snapshot' => 'manual', 'dry-run' => true ) );
+	revenue_command_test_assert_synopsis_accepts_documented_options( 'pages', array( 'period' => '2026-05', 'period-start' => '2026-05-01', 'period-end' => '2026-05-31', 'batch' => 'rev-mediavine-42-2026-05', 'blog-id' => '1', 'hostname' => 'extrachill.com', 'cohort' => 'resolved', 'min-views' => '1000', 'sort-by' => 'views', 'order' => 'desc', 'limit' => '25', 'format' => 'json' ) );
+	revenue_command_test_assert_synopsis_accepts_documented_options( 'rollup', array( 'group-by' => 'format', 'period' => '2026-05', 'period-start' => '2026-05-01', 'period-end' => '2026-05-31', 'batch' => 'rev-mediavine-42-2026-05', 'hostname' => 'extrachill.com', 'limit' => '100', 'format' => 'json' ) );
+	revenue_command_test_assert_synopsis_accepts_documented_options( 'arc', array( 'include-alltime' => true, 'format' => 'json' ) );
+	revenue_command_test_assert_synopsis_accepts_documented_options( 'diagnose', array( 'period' => '2026-05', 'period-start' => '2026-05-01', 'period-end' => '2026-05-31', 'batch' => 'rev-mediavine-42-2026-05', 'blog-id' => '1', 'hostname' => 'extrachill.com', 'format' => 'json' ) );
 	$command->fetch( array(), array( 'start' => '2026-05-01', 'end' => '2026-05-31', 'period' => '2026-05', 'site-id' => '42', 'dry-run' => true ) );
 	revenue_command_test_assert_same(
 		array( array( 'action' => 'backfill', 'periods' => array( array( 'period' => '2026-05', 'start_date' => '2026-05-01', 'end_date' => '2026-05-31' ) ), 'site_id' => '42' ) ),


### PR DESCRIPTION
## Summary
- Fixes #97 by adding explicit WP-CLI synopses for every revenue subcommand, so documented filters pass pre-dispatch validation.
- Accepted options: `fetch` (`start`, `end`, `period`, `periods`, `site-id`, `hostname`, `mode`, `snapshot`, `dry-run`); `pages` (`period`, `period-start`, `period-end`, `batch`, `blog-id`, `hostname`, `cohort`, `min-views`, `sort-by`, `order`, `limit`, `format`); `rollup` (`group-by`, `period`, `period-start`, `period-end`, `batch`, `hostname`, `limit`, `format`); `arc` (`include-alltime`, `format`); and `diagnose` (`period`, `period-start`, `period-end`, `batch`, `blog-id`, `hostname`, `format`).
- Mapping remains Ability-only: this changes CLI argument acceptance and adds coverage without adding revenue domain logic.

## Verification
- `WP_CLI_RUNTIME_PATH=/var/www/extrachill.com php tests/RevenueCommandRuntimeTest.php` dispatches the worktree plugin through a real WP-CLI runtime with plugins skipped. It verifies representative documented value/flag options for `fetch`, `pages`, `rollup`, `arc`, and `diagnose` reach the expected missing-Ability boundary rather than failing pre-dispatch with parameter errors.
- `php tests/RevenueCommandTest.php`
- `php -l tests/RevenueCommandTest.php`
- `php -l tests/RevenueCommandRuntimeBootstrap.php`
- `php -l tests/RevenueCommandRuntimeTest.php`
- `git diff --check`
- `homeboy --force-hot --allow-local-hot review extrachill-cli lint --path=/var/lib/datamachine/workspace/extrachill-cli@fix-revenue-filter-synopses --changed-only` (PHPCS passed with no findings)