### PR TITLE
fix: preserve retention referrer details

### DIFF
--- a/homeboy.json
+++ b/homeboy.json
@@ -11,6 +11,7 @@
       "php tests/QRCodeCommandTest.php",
       "php tests/CrosslinkTargetsCommandTest.php",
       "php tests/ConversionCommandTest.php",
+      "php tests/RetentionCommandTest.php",
       "php tests/UserLocalSceneCommandTest.php",
       "php tests/RevenueCommandTest.php",
       "php tests/RevenueCommandRuntimeTest.php"

--- a/inc/Commands/Analytics/RetentionCommand.php
+++ b/inc/Commands/Analytics/RetentionCommand.php
@@ -101,11 +101,16 @@ class RetentionCommand {
 			WP_CLI::error( $result->get_error_message() );
 		}
 
-		if ( 'table' !== $format ) {
+		if ( 'json' === $format ) {
+			WP_CLI::print_value( $result, array( 'format' => $format ) );
+			return;
+		}
+
+		if ( 'csv' === $format ) {
 			Utils\format_items(
 				$format,
-				$this->cohort_rows( $result ),
-				array( 'cohort_week', 'cohort_size', 'retention_w1', 'retention_w2' )
+				array( $this->csv_row( $result ) ),
+				array_keys( $result )
 			);
 			return;
 		}
@@ -153,10 +158,37 @@ class RetentionCommand {
 		$rows = $this->cohort_rows( $result );
 		if ( empty( $rows ) ) {
 			WP_CLI::log( '  (no cohorts in window)' );
+		} else {
+			Utils\format_items( 'table', $rows, array( 'cohort_week', 'cohort_size', 'retention_w1', 'retention_w2' ) );
+		}
+
+		WP_CLI::log( '' );
+		WP_CLI::log( 'Referrer-host landings:' );
+		$referrer_rows = $this->referrer_rows( $result );
+		if ( empty( $referrer_rows ) ) {
+			WP_CLI::log( '  (no referrer hosts in window)' );
 			return;
 		}
 
-		Utils\format_items( 'table', $rows, array( 'cohort_week', 'cohort_size', 'retention_w1', 'retention_w2' ) );
+		Utils\format_items( 'table', $referrer_rows, array( 'referrer_host', 'landings' ) );
+	}
+
+	/**
+	 * Preserve the complete response envelope in a deterministic CSV row.
+	 *
+	 * Nested values are JSON-encoded because CSV cells cannot represent arrays.
+	 *
+	 * @param array $result Ability result.
+	 * @return array<string, mixed>
+	 */
+	private function csv_row( array $result ) {
+		foreach ( $result as $key => $value ) {
+			if ( is_array( $value ) || is_object( $value ) ) {
+				$result[ $key ] = wp_json_encode( $value );
+			}
+		}
+
+		return $result;
 	}
 
 	/**
@@ -173,8 +205,28 @@ class RetentionCommand {
 			$rows[] = array(
 				'cohort_week'  => $c['cohort_week'],
 				'cohort_size'  => number_format( (int) $c['cohort_size'] ),
-				'retention_w1' => number_format( (float) $c['retention_w1'] * 100, 1 ) . '%',
-				'retention_w2' => number_format( (float) $c['retention_w2'] * 100, 1 ) . '%',
+				'retention_w1' => null === $c['retention_w1'] ? 'n/a' : number_format( (float) $c['retention_w1'] * 100, 1 ) . '%',
+				'retention_w2' => null === $c['retention_w2'] ? 'n/a' : number_format( (float) $c['retention_w2'] * 100, 1 ) . '%',
+			);
+		}
+
+		return $rows;
+	}
+
+	/**
+	 * Build display rows for referrer-host landings.
+	 *
+	 * @param array $result Ability result.
+	 * @return array<int, array<string, string>>
+	 */
+	private function referrer_rows( array $result ) {
+		$hosts = isset( $result['by_referrer_host']['hosts'] ) ? $result['by_referrer_host']['hosts'] : array();
+		$rows  = array();
+
+		foreach ( $hosts as $host ) {
+			$rows[] = array(
+				'referrer_host' => (string) $host['referrer_host'],
+				'landings'      => number_format( (int) $host['landings'] ),
 			);
 		}
 

--- a/tests/RetentionCommandTest.php
+++ b/tests/RetentionCommandTest.php
@@ -1,0 +1,141 @@
+<?php
+/**
+ * Focused machine and table presenter tests for the retention command.
+ */
+
+namespace {
+	define( 'ABSPATH', __DIR__ . '/' );
+
+	class WP_CLI {
+		public static $messages = array();
+		public static $printed  = array();
+
+		public static function error( $message ) {
+			throw new RuntimeException( $message );
+		}
+
+		public static function log( $message ) {
+			self::$messages[] = $message;
+		}
+
+		public static function print_value( $value, $args ) {
+			self::$printed[] = compact( 'value', 'args' );
+		}
+	}
+
+	class RetentionCommandTestAbility {
+		public $result;
+
+		public function __construct( $result ) {
+			$this->result = $result;
+		}
+
+		public function execute( $input ) {
+			return $this->result;
+		}
+	}
+
+	$retention_command_test_result = array(
+		'return_rate'       => array( 'total_visitors' => 1200, 'returning_visitors' => 300, 'rate' => 0.25, 'definition' => 'Returning visitors.' ),
+		'cohort_retention'  => array(
+			'cohorts'    => array(
+				array( 'cohort_week' => '2026-W25', 'cohort_size' => 100, 'retention_w1' => 0.2, 'retention_w2' => 0.1 ),
+				array( 'cohort_week' => '2026-W27', 'cohort_size' => 50, 'retention_w1' => null, 'retention_w2' => null ),
+			),
+			'weeks'      => 8,
+			'definition' => 'Incomplete horizons are null.',
+		),
+		'cross_site_return' => array( 'total_visitors' => 1200, 'cross_site_visitors' => 120, 'rate' => 0.1, 'definition' => 'Cross-site visitors.' ),
+		'session_depth'     => array( 'avg_pageviews_per_visitor_day' => 2.4, 'max_pageviews_per_visitor_day' => 12, 'definition' => 'Session depth.' ),
+		'by_referrer_host'  => array(
+			'hosts'      => array(
+				array( 'referrer_host' => 'chatgpt.com', 'landings' => 1234 ),
+				array( 'referrer_host' => 'community.extrachill.com', 'landings' => 98 ),
+			),
+			'definition' => 'Top cross-surface referrer hosts.',
+		),
+		'days'              => 28,
+		'end_days_ago'      => 0,
+		'blog_id'           => 0,
+		'period'            => '2026-06-18 to 2026-07-16',
+		'since'             => '2026-06-18 00:00:00',
+		'until'             => '2026-07-16 00:00:00',
+		'as_of'             => '2026-07-16 12:00:00',
+		'note'              => 'Deterministic and bot-filtered.',
+		'future_metric'     => array( 'count' => 7, 'rate' => 0.5 ),
+	);
+	$retention_command_test_ability = new RetentionCommandTestAbility( $retention_command_test_result );
+
+	function wp_get_ability( $name ) {
+		global $retention_command_test_ability;
+		return 'extrachill/get-retention-stats' === $name ? $retention_command_test_ability : null;
+	}
+
+	function is_wp_error( $value ) {
+		return false;
+	}
+
+	function wp_json_encode( $value ) {
+		return json_encode( $value );
+	}
+
+	function get_current_blog_id() {
+		return 1;
+	}
+
+	function retention_command_test_assert_same( $expected, $actual, $message ) {
+		if ( $expected !== $actual ) {
+			throw new RuntimeException( $message . '\nExpected: ' . var_export( $expected, true ) . '\nActual: ' . var_export( $actual, true ) );
+		}
+	}
+
+	function retention_command_test_assert_true( $actual, $message ) {
+		if ( ! $actual ) {
+			throw new RuntimeException( $message );
+		}
+	}
+}
+
+namespace WP_CLI\Utils {
+	$retention_command_test_formats = array();
+
+	function format_items( $format, $items, $fields ) {
+		global $retention_command_test_formats;
+		$retention_command_test_formats[] = compact( 'format', 'items', 'fields' );
+	}
+}
+
+namespace {
+	require_once dirname( __DIR__ ) . '/inc/Traits/NetworkAwareTrait.php';
+	require_once dirname( __DIR__ ) . '/inc/Commands/Analytics/RetentionCommand.php';
+
+	use ExtraChill\CLI\Commands\Analytics\RetentionCommand;
+
+	global $retention_command_test_formats, $retention_command_test_result;
+
+	$command = new RetentionCommand();
+	$command( array(), array( 'format' => 'json' ) );
+	retention_command_test_assert_same( $retention_command_test_result, WP_CLI::$printed[0]['value'], 'JSON must preserve the complete typed ability result.' );
+	retention_command_test_assert_same( array( 'format' => 'json' ), WP_CLI::$printed[0]['args'], 'JSON must use WP-CLI structured output.' );
+	retention_command_test_assert_same( null, $retention_command_test_result['cohort_retention']['cohorts'][1]['retention_w1'], 'Incomplete cohort horizons must remain null in machine output.' );
+
+	$command( array(), array( 'format' => 'csv' ) );
+	$csv = $retention_command_test_formats[0];
+	retention_command_test_assert_same( array_keys( $retention_command_test_result ), $csv['fields'], 'CSV must retain every top-level ability field without a presenter allowlist.' );
+	retention_command_test_assert_same( 28, $csv['items'][0]['days'], 'CSV scalar values must retain their source type before formatting.' );
+	retention_command_test_assert_same( $retention_command_test_result['by_referrer_host'], json_decode( $csv['items'][0]['by_referrer_host'], true ), 'CSV must preserve nested referrer-host detail as JSON.' );
+	retention_command_test_assert_same( $retention_command_test_result['future_metric'], json_decode( $csv['items'][0]['future_metric'], true ), 'CSV must preserve newly added ability fields without presenter changes.' );
+
+	$command( array(), array() );
+	$cohorts  = $retention_command_test_formats[1];
+	$referrers = $retention_command_test_formats[2];
+	retention_command_test_assert_same( array( 'cohort_week', 'cohort_size', 'retention_w1', 'retention_w2' ), $cohorts['fields'], 'Existing cohort table columns must remain backward compatible.' );
+	retention_command_test_assert_same( 'n/a', $cohorts['items'][1]['retention_w1'], 'Incomplete W1 horizons must not display as zero retention.' );
+	retention_command_test_assert_same( 'n/a', $cohorts['items'][1]['retention_w2'], 'Incomplete W2 horizons must not display as zero retention.' );
+	retention_command_test_assert_same( array( 'referrer_host', 'landings' ), $referrers['fields'], 'Table output must include the referrer-host section.' );
+	retention_command_test_assert_same( 'chatgpt.com', $referrers['items'][0]['referrer_host'], 'Referrer host names must survive table presentation.' );
+	retention_command_test_assert_same( '1,234', $referrers['items'][0]['landings'], 'Referrer landings must use human count formatting.' );
+	retention_command_test_assert_true( in_array( 'Referrer-host landings:', WP_CLI::$messages, true ), 'Human output must label the referrer-host section.' );
+
+	fwrite( STDOUT, "RetentionCommand tests passed.\n" );
+}


### PR DESCRIPTION
## Summary
- preserve the complete typed retention ability envelope for JSON instead of emitting formatted cohort rows
- emit a deterministic single-row CSV containing every top-level ability field, with nested sections JSON-encoded so referrer and cohort detail survives
- add a human-readable referrer-host landings table while preserving existing cohort columns and displaying incomplete cohort horizons as `n/a`
- add focused presenter coverage that proves current and future ability fields are not silently discarded

Closes #102

## Output changes
- Human/table: retains the existing summary and cohort table, then adds `Referrer-host landings` with `referrer_host` and `landings` columns.
- JSON: now returns the exact typed ability response envelope, including `by_referrer_host`, definitions, window metadata, and nullable immature cohort horizons.
- CSV: changes from flattened cohort rows to one complete response-envelope row. Nested arrays/objects are deterministic JSON cell values; scalar fields retain their source values before WP-CLI serialization.

## Tests
- `php tests/RetentionCommandTest.php`
- all seven PHP scripts configured in `homeboy.json`
- `php -l inc/Commands/Analytics/RetentionCommand.php`
- `php -l tests/RetentionCommandTest.php`
- `git diff --check`

## Limitations
- CSV cannot represent nested typed structures natively, so nested ability sections are JSON-encoded within cells.
- `homeboy review extrachill-cli` was attempted but did not start: Homeboy refused local execution because the host load was 182.3 across 8 CPUs and no eligible Lab runner was available. No review checks failed; the review was not run.