### PR TITLE
fix: preserve conversion outcome envelope

### DIFF
--- a/inc/Commands/Analytics/ConversionCommand.php
+++ b/inc/Commands/Analytics/ConversionCommand.php
@@ -121,14 +121,17 @@ class ConversionCommand {
 			WP_CLI::error( $result->get_error_message() );
 		}
 
-		if ( 'table' !== $format ) {
-			$rows    = ( 'article' === $by )
-				? array_map( array( $this, 'article_machine_row' ), (array) ( $result['by_article'] ?? array() ) )
-				: array_map( array( $this, 'category_machine_row' ), (array) ( $result['by_category'] ?? array() ) );
-			$columns = ( 'article' === $by )
-				? array( 'post_id', 'title', 'url', 'path', 'entry_sessions', 'reached_any', 'reached_any_rate', 'reached_any_same_count', 'same_session_rate', 'reached_any_return_count', 'return_rate', 'returned_count', 'returned_rate' )
-				: array( 'term_id', 'category', 'entry_sessions', 'reached_any', 'reached_any_rate', 'reached_any_same_count', 'same_session_rate', 'reached_any_return_count', 'return_rate', 'returned_count', 'returned_rate' );
-			Utils\format_items( $format, $rows, $columns );
+		if ( 'json' === $format ) {
+			WP_CLI::print_value( $result, array( 'format' => $format ) );
+			return;
+		}
+
+		if ( 'csv' === $format ) {
+			Utils\format_items(
+				$format,
+				array( $this->csv_row( $result ) ),
+				array_keys( $result )
+			);
 			return;
 		}
 
@@ -204,57 +207,21 @@ class ConversionCommand {
 	}
 
 	/**
-	 * Build a typed machine-readable row for an entry article.
+	 * Preserve the complete response envelope in a deterministic CSV row.
 	 *
-	 * @param array $a Article result row.
-	 * @return array<string, int|float|string>
+	 * Nested values are JSON-encoded because CSV cells cannot represent arrays.
+	 *
+	 * @param array $result Ability result.
+	 * @return array<string, mixed>
 	 */
-	private function article_machine_row( $a ) {
-		return array_merge(
-			array(
-				'post_id' => (int) ( $a['post_id'] ?? 0 ),
-				'title'   => (string) ( $a['title'] ?? '(unknown)' ),
-				'url'     => (string) ( $a['url'] ?? '' ),
-				'path'    => (string) ( $a['path'] ?? '' ),
-			),
-			$this->machine_metrics( $a )
-		);
-	}
+	private function csv_row( array $result ) {
+		foreach ( $result as $key => $value ) {
+			if ( is_array( $value ) || is_object( $value ) ) {
+				$result[ $key ] = wp_json_encode( $value );
+			}
+		}
 
-	/**
-	 * Build a typed machine-readable row for an entry category.
-	 *
-	 * @param array $c Category result row.
-	 * @return array<string, int|float|string>
-	 */
-	private function category_machine_row( $c ) {
-		return array_merge(
-			array(
-				'term_id'  => (int) ( $c['term_id'] ?? 0 ),
-				'category' => (string) ( $c['category'] ?? '' ),
-			),
-			$this->machine_metrics( $c )
-		);
-	}
-
-	/**
-	 * Flatten typed ability metrics for deterministic JSON and CSV rows.
-	 *
-	 * @param array $row Ability result row.
-	 * @return array<string, int|float>
-	 */
-	private function machine_metrics( $row ) {
-		return array(
-			'entry_sessions'           => (int) ( $row['entry_sessions'] ?? 0 ),
-			'reached_any'              => (int) ( $row['reached_any'] ?? 0 ),
-			'reached_any_rate'         => (float) ( $row['reached_any_rate'] ?? 0 ),
-			'reached_any_same_count'   => (int) ( $row['reached_any_same_count'] ?? 0 ),
-			'same_session_rate'        => (float) ( $row['same_session']['any'] ?? 0 ),
-			'reached_any_return_count' => (int) ( $row['reached_any_return_count'] ?? 0 ),
-			'return_rate'              => (float) ( $row['return']['any'] ?? 0 ),
-			'returned_count'           => (int) ( $row['returned_count'] ?? 0 ),
-			'returned_rate'            => (float) ( $row['returned_rate'] ?? 0 ),
-		);
+		return $result;
 	}
 
 	/**

--- a/tests/ConversionCommandTest.php
+++ b/tests/ConversionCommandTest.php
@@ -8,6 +8,7 @@ namespace {
 
 	class WP_CLI {
 		public static $messages = array();
+		public static $printed  = array();
 
 		public static function error( $message ) {
 			throw new RuntimeException( $message );
@@ -16,47 +17,67 @@ namespace {
 		public static function log( $message ) {
 			self::$messages[] = $message;
 		}
-	}
 
-	class ConversionCommandTestAbility {
-		public function execute( $input ) {
-			return array(
-				'period'          => '2025-07-16 to 2026-07-16',
-				'since'           => '2025-07-16 00:00:00',
-				'as_of'           => '2026-07-16 00:00:00',
-				'entry_blog_id'   => 1,
-				'platform_blogs'  => array(),
-				'overall'         => array(
-					'entry_sessions'  => 1234,
-					'reached_any'     => 321,
-					'reached_any_rate'=> 0.2601,
-					'same_session'    => array( 'events' => 0.1, 'community' => 0.05, 'artist' => 0.02, 'any' => 0.17 ),
-					'return'          => array( 'events' => 0.04, 'community' => 0.03, 'artist' => 0.02, 'any' => 0.09 ),
-					'returned_rate'   => 0.42,
-				),
-				'by_article'      => array(
-					array(
-						'post_id'                  => 173,
-						'title'                    => 'Mama Say Mama Sa Mama Coosa: The Story Behind an Iconic Michael Jackson Lyric',
-						'url'                      => 'https://extrachill.com/mama-say-mama-sa-mama-coosa/',
-						'path'                     => '/mama-say-mama-sa-mama-coosa/',
-						'entry_sessions'           => 1234,
-						'reached_any'              => 321,
-						'reached_any_rate'         => 0.2601,
-						'reached_any_same_count'   => 210,
-						'same_session'             => array( 'any' => 0.1702 ),
-						'reached_any_return_count' => 111,
-						'return'                   => array( 'any' => 0.0899 ),
-						'returned_count'           => 518,
-						'returned_rate'            => 0.4198,
-					),
-				),
-				'by_category'     => array(),
-			);
+		public static function print_value( $value, $args ) {
+			self::$printed[] = compact( 'value', 'args' );
 		}
 	}
 
-	$conversion_command_test_ability = new ConversionCommandTestAbility();
+	class ConversionCommandTestAbility {
+		public $result;
+
+		public function __construct( $result ) {
+			$this->result = $result;
+		}
+
+		public function execute( $input ) {
+			return $this->result;
+		}
+	}
+
+	$conversion_command_test_result = array(
+		'period'         => '2025-07-16 to 2026-07-16',
+		'since'          => '2025-07-16 00:00:00',
+		'as_of'          => '2026-07-16 00:00:00',
+		'entry_blog_id'  => 1,
+		'platform_blogs' => array(),
+		'overall'        => array(
+			'entry_sessions'   => 1234,
+			'reached_any'      => 321,
+			'reached_any_rate' => 0.2601,
+			'same_session'     => array( 'events' => 0.1, 'community' => 0.05, 'artist' => 0.02, 'any' => 0.17 ),
+			'return'           => array( 'events' => 0.04, 'community' => 0.03, 'artist' => 0.02, 'any' => 0.09 ),
+			'returned_rate'    => 0.42,
+		),
+		'by_article'     => array(
+			array(
+				'post_id'                  => 173,
+				'title'                    => 'Mama Say Mama Sa Mama Coosa: The Story Behind an Iconic Michael Jackson Lyric',
+				'url'                      => 'https://extrachill.com/mama-say-mama-sa-mama-coosa/',
+				'path'                     => '/mama-say-mama-sa-mama-coosa/',
+				'entry_sessions'           => 1234,
+				'reached_any'              => 321,
+				'reached_any_rate'         => 0.2601,
+				'reached_any_same_count'   => 210,
+				'same_session'             => array( 'any' => 0.1702 ),
+				'reached_any_return_count' => 111,
+				'return'                   => array( 'any' => 0.0899 ),
+				'returned_count'           => 518,
+				'returned_rate'            => 0.4198,
+			),
+		),
+		'by_category'    => array(),
+		'outcomes'       => array(
+			'overall'               => array( 'newsletter_signup' => array( 'count' => 12, 'rate' => 0.0097 ) ),
+			'by_article'            => array( array( 'post_id' => 173, 'newsletter_signup' => array( 'count' => 4, 'rate' => 0.0032 ) ) ),
+			'by_category'           => array(),
+			'coverage'              => array( 'identified_visitors' => 0.82, 'newsletter_events' => 0.76 ),
+			'attribution_semantics' => array( 'direct_source' => 'Entry article was the direct source.' ),
+		),
+		'future_metric'  => array( 'count' => 7, 'rate' => 0.5 ),
+	);
+
+	$conversion_command_test_ability = new ConversionCommandTestAbility( $conversion_command_test_result );
 
 	function wp_get_ability( $name ) {
 		global $conversion_command_test_ability;
@@ -92,26 +113,25 @@ namespace {
 
 	use ExtraChill\CLI\Commands\Analytics\ConversionCommand;
 
-	global $conversion_command_test_formats;
+	global $conversion_command_test_formats, $conversion_command_test_result;
 
 	$command = new ConversionCommand();
 	$command( array(), array( 'by' => 'article', 'format' => 'json' ) );
+	conversion_command_test_assert_same( $conversion_command_test_result, WP_CLI::$printed[0]['value'], 'JSON must preserve the complete typed ability result.' );
+	conversion_command_test_assert_same( array( 'format' => 'json' ), WP_CLI::$printed[0]['args'], 'JSON must use WP-CLI structured output.' );
+	conversion_command_test_assert_same( 0.82, WP_CLI::$printed[0]['value']['outcomes']['coverage']['identified_visitors'], 'JSON must retain outcome coverage.' );
+	conversion_command_test_assert_same( $conversion_command_test_result['future_metric'], WP_CLI::$printed[0]['value']['future_metric'], 'JSON must retain newly added ability fields without presenter changes.' );
+
 	$command( array(), array( 'by' => 'article', 'format' => 'csv' ) );
 	$command( array(), array( 'by' => 'article' ) );
 
-	$machine_fields = array( 'post_id', 'title', 'url', 'path', 'entry_sessions', 'reached_any', 'reached_any_rate', 'reached_any_same_count', 'same_session_rate', 'reached_any_return_count', 'return_rate', 'returned_count', 'returned_rate' );
-	foreach ( array( 0, 1 ) as $index ) {
-		$row = $conversion_command_test_formats[ $index ]['items'][0];
-		conversion_command_test_assert_same( $machine_fields, $conversion_command_test_formats[ $index ]['fields'], 'Machine fields must expose stable identity and explicit typed metrics.' );
-		conversion_command_test_assert_same( 173, $row['post_id'], 'Post ID must remain an integer.' );
-		conversion_command_test_assert_same( 'Mama Say Mama Sa Mama Coosa: The Story Behind an Iconic Michael Jackson Lyric', $row['title'], 'Machine titles must not be truncated.' );
-		conversion_command_test_assert_same( 'https://extrachill.com/mama-say-mama-sa-mama-coosa/', $row['url'], 'Machine rows must expose the canonical URL.' );
-		conversion_command_test_assert_same( '/mama-say-mama-sa-mama-coosa/', $row['path'], 'Machine rows must expose the canonical path.' );
-		conversion_command_test_assert_same( 1234, $row['entry_sessions'], 'Counts must remain integers.' );
-		conversion_command_test_assert_same( 0.2601, $row['reached_any_rate'], 'Rates must remain numeric 0..1 values.' );
-	}
+	$csv = $conversion_command_test_formats[0];
+	conversion_command_test_assert_same( array_keys( $conversion_command_test_result ), $csv['fields'], 'CSV must retain every top-level ability field without a presenter allowlist.' );
+	conversion_command_test_assert_same( '2025-07-16 to 2026-07-16', $csv['items'][0]['period'], 'CSV scalar values must retain their source type before formatting.' );
+	conversion_command_test_assert_same( $conversion_command_test_result['outcomes'], json_decode( $csv['items'][0]['outcomes'], true ), 'CSV must preserve the complete outcomes envelope as JSON.' );
+	conversion_command_test_assert_same( $conversion_command_test_result['future_metric'], json_decode( $csv['items'][0]['future_metric'], true ), 'CSV must preserve newly added ability fields without presenter changes.' );
 
-	$table = $conversion_command_test_formats[2];
+	$table = $conversion_command_test_formats[1];
 	conversion_command_test_assert_same( array( 'title', 'entry_sessions', 'same_any', 'return_any', 'returned', 'reached_any' ), $table['fields'], 'Table columns must remain backward compatible.' );
 	conversion_command_test_assert_same( 'Mama Say Mama Sa Mama Coosa: The Story Behind an Iconic…', $table['items'][0]['title'], 'Table titles must retain compact display truncation.' );
 	conversion_command_test_assert_same( '1,234', $table['items'][0]['entry_sessions'], 'Table counts must retain human formatting.' );


### PR DESCRIPTION
## Summary
- return the complete typed conversion-map ability response for JSON output
- represent CSV as one complete envelope row, JSON-encoding nested values without a presenter allowlist
- preserve the existing curated article/category table output

## Compatibility
- JSON now returns the full ability envelope instead of the selected flattened `--by` rows; `--by` continues to control table presentation only
- CSV now emits one row with every top-level ability field in source order; arrays and objects are JSON-encoded within their cells
- unknown future top-level fields are preserved automatically in both machine formats

## Tests
- `php tests/QRCodeCommandTest.php`
- `php tests/CrosslinkTargetsCommandTest.php`
- `php tests/ConversionCommandTest.php`
- `php tests/RetentionCommandTest.php`
- `php tests/UserLocalSceneCommandTest.php`
- `php tests/RevenueCommandTest.php`
- `php tests/RevenueCommandRuntimeTest.php`
- `php -l inc/Commands/Analytics/ConversionCommand.php`
- `php -l tests/ConversionCommandTest.php`
- `git diff --check`

## Limitations
- This changes the JSON and CSV output shape from flattened ranking rows to the complete ability envelope; human table output is unchanged
- Homeboy review was skipped by resource policy because the host was hot (load 123.2 on 8 CPUs) and no eligible Lab runner was available

Closes #104