### PR TITLE
fix: align outbound source coverage contract

### DIFF
--- a/homeboy.json
+++ b/homeboy.json
@@ -10,6 +10,7 @@
     "test": [
       "php tests/QRCodeCommandTest.php",
       "php tests/CrosslinkTargetsCommandTest.php",
+      "php tests/OutboundCommandTest.php",
       "php tests/ConversionCommandTest.php",
       "php tests/SummaryCommandTest.php",
       "php tests/RetentionCommandTest.php",

--- a/inc/Commands/Analytics/OutboundCommand.php
+++ b/inc/Commands/Analytics/OutboundCommand.php
@@ -2,7 +2,7 @@
 /**
  * Analytics Outbound CLI Command
  *
- * Surfaces the first-party, bot-filtered outbound-click report from the
+ * Surfaces the first-party outbound-click report from the
  * extrachill-analytics plugin via the extrachill/get-outbound-clicks ability:
  * where readers EXIT the network to external domains (Spotify, ticketing,
  * artist sites, merch, social), grouped by category, top destination host, and
@@ -28,8 +28,9 @@ class OutboundCommand {
 	 * Where readers exit the Extra Chill network to external domains, grouped
 	 * into actionable destination categories (spotify/social/ticketing/
 	 * artist-site/merch/other), ranked by top destination host, and ranked by
-	 * the top source pages that drive the most exits. Deterministic +
-	 * bot-filtered from the sendBeacon outbound_click events.
+	 * the top source pages that drive the most exits. Deterministic from the
+	 * stored sendBeacon outbound_click events. All stored rows are counted: the
+	 * generic REST bot stamp does not reliably classify these browser beacons.
 	 *
 	 * The outbound_click event is NEW — it captures exits going forward only,
 	 * so a low or zero total IS the young-data state, not a bug.
@@ -79,7 +80,9 @@ class OutboundCommand {
 	 * ---
 	 *
 	 * [--include-bots]
-	 * : Include rows flagged as bot at write time (default: humans only).
+	 * : Deprecated compatibility flag; ignored. The report always includes all
+	 * stored outbound browser beacons because their generic REST bot stamp is
+	 * not a trustworthy human/bot filter.
 	 *
 	 * [--format=<format>]
 	 * : Output format.
@@ -123,11 +126,10 @@ class OutboundCommand {
 
 		$result = $ability->execute(
 			array(
-				'days'         => $days,
-				'blog_id'      => $blog_id,
-				'category'     => $category,
-				'limit'        => $limit,
-				'include_bots' => isset( $assoc_args['include-bots'] ),
+				'days'     => $days,
+				'blog_id'  => $blog_id,
+				'category' => $category,
+				'limit'    => $limit,
 			)
 		);
 

--- a/tests/OutboundCommandTest.php
+++ b/tests/OutboundCommandTest.php
@@ -1,0 +1,142 @@
+<?php
+/**
+ * Focused contract and presenter tests for the outbound command.
+ */
+
+namespace {
+	define( 'ABSPATH', __DIR__ . '/' );
+
+	class WP_CLI {
+		public static $messages = array();
+
+		public static function error( $message ) {
+			throw new RuntimeException( $message );
+		}
+
+		public static function log( $message ) {
+			self::$messages[] = $message;
+		}
+	}
+
+	class OutboundCommandTestAbility {
+		public $inputs = array();
+
+		public function execute( $input ) {
+			$this->inputs[] = $input;
+
+			return array(
+				'period'         => '2026-06-19 to 2026-07-17',
+				'total'          => 1234,
+				'by_category'    => array(
+					array(
+						'category' => 'ticketing',
+						'clicks'   => 1234,
+						'share'    => 1,
+					),
+				),
+				'by_destination' => array(),
+				'by_source'      => array(),
+				'note'           => 'All stored outbound browser beacons are counted.',
+			);
+		}
+	}
+
+	$outbound_command_test_ability = new OutboundCommandTestAbility();
+
+	function wp_get_ability( $name ) {
+		global $outbound_command_test_ability;
+
+		if ( 'extrachill/get-outbound-clicks' !== $name ) {
+			throw new RuntimeException( 'Unexpected ability requested: ' . $name );
+		}
+
+		return $outbound_command_test_ability;
+	}
+
+	function is_wp_error( $value ) {
+		return false;
+	}
+
+	function outbound_command_test_assert_same( $expected, $actual, $message ) {
+		if ( $expected !== $actual ) {
+			throw new RuntimeException(
+				$message . '\nExpected: ' . var_export( $expected, true ) . '\nActual: ' . var_export( $actual, true )
+			);
+		}
+	}
+
+	function outbound_command_test_assert_contains( $needle, $haystack, $message ) {
+		if ( false === strpos( $haystack, $needle ) ) {
+			throw new RuntimeException( $message . '\nMissing: ' . $needle );
+		}
+	}
+}
+
+namespace WP_CLI\Utils {
+	$outbound_command_test_formats = array();
+
+	function format_items( $format, $items, $fields ) {
+		global $outbound_command_test_formats;
+
+		$outbound_command_test_formats[] = compact( 'format', 'items', 'fields' );
+	}
+}
+
+namespace {
+	require_once dirname( __DIR__ ) . '/inc/Commands/Analytics/OutboundCommand.php';
+
+	use ExtraChill\CLI\Commands\Analytics\OutboundCommand;
+
+	global $outbound_command_test_ability, $outbound_command_test_formats;
+
+	$help = ( new ReflectionMethod( OutboundCommand::class, '__invoke' ) )->getDocComment();
+	outbound_command_test_assert_contains( '[--include-bots]', $help, 'Help must retain the legacy option for compatibility.' );
+	outbound_command_test_assert_contains( 'Deprecated compatibility flag; ignored.', $help, 'Help must identify the legacy option as a no-op.' );
+	outbound_command_test_assert_contains( 'always includes all', $help, 'Help must document actual stored-row coverage.' );
+	outbound_command_test_assert_contains( 'not a trustworthy human/bot filter', $help, 'Help must explain why no human-only claim is made.' );
+
+	$command = new OutboundCommand();
+	$command(
+		array(),
+		array(
+			'days'         => '7',
+			'blog-id'      => '2',
+			'category'     => 'ticketing',
+			'limit'        => '10',
+			'by'           => 'category',
+			'format'       => 'json',
+			'include-bots' => true,
+		)
+	);
+
+	$expected_input = array(
+		'days'     => 7,
+		'blog_id'  => 2,
+		'category' => 'ticketing',
+		'limit'    => 10,
+	);
+	outbound_command_test_assert_same( $expected_input, $outbound_command_test_ability->inputs[0], 'Only supported ability arguments may be mapped.' );
+	outbound_command_test_assert_same( false, array_key_exists( 'include_bots', $outbound_command_test_ability->inputs[0] ), 'The deprecated flag must not imply filtering through ability input.' );
+	outbound_command_test_assert_same( 'json', $outbound_command_test_formats[0]['format'], 'JSON output format must be preserved.' );
+	outbound_command_test_assert_same( array( 'category', 'clicks', 'share' ), $outbound_command_test_formats[0]['fields'], 'JSON columns must remain backward compatible.' );
+	outbound_command_test_assert_same( '1,234', $outbound_command_test_formats[0]['items'][0]['clicks'], 'JSON row formatting must remain backward compatible.' );
+	outbound_command_test_assert_same( '100.0%', $outbound_command_test_formats[0]['items'][0]['share'], 'JSON percentage formatting must remain backward compatible.' );
+
+	$command( array(), array() );
+	outbound_command_test_assert_same(
+		array(
+			'days'     => 28,
+			'blog_id'  => 0,
+			'category' => '',
+			'limit'    => 25,
+		),
+		$outbound_command_test_ability->inputs[1],
+		'Default argument mapping must remain stable.'
+	);
+	outbound_command_test_assert_same( 'table', $outbound_command_test_formats[1]['format'], 'Table output format must be preserved.' );
+	outbound_command_test_assert_same( array( 'category', 'clicks', 'share' ), $outbound_command_test_formats[1]['fields'], 'Table columns must remain backward compatible.' );
+	outbound_command_test_assert_contains( 'Total outbound clicks: 1,234', implode( "\n", WP_CLI::$messages ), 'Table summary must retain formatted totals.' );
+	outbound_command_test_assert_contains( 'All stored outbound browser beacons are counted.', implode( "\n", WP_CLI::$messages ), 'Table output must retain the ability coverage note.' );
+
+	fwrite( STDOUT, "OutboundCommand tests passed.\n" );
+}


### PR DESCRIPTION
## Summary
- correct `analytics outbound` help to state that all stored `sendBeacon` rows are counted because the generic REST bot stamp is not a trustworthy filter
- retain `--include-bots` as a deprecated compatibility no-op while no longer mapping it to the owning ability
- add focused help, argument mapping, legacy flag, table, and JSON compatibility coverage to the full test suite

## Semantics
The owning `extrachill/get-outbound-clicks` ability exposes `include_bots` only as a deprecated compatibility input and deliberately ignores it. This adapter therefore performs no fake human/bot filtering: both the default invocation and legacy `--include-bots` invocation report the same stored outbound browser beacons.

## Tests
- `php tests/OutboundCommandTest.php`
- all `tests/*Test.php` scripts (9 passed)
- PHP syntax checks for changed PHP files
- Homeboy PHPCS lint on changed files (0 findings)
- Homeboy audit against `origin/main` (0 findings)
- worktree plugin command registration/help and execution smoke
- `git diff --check`

Closes #108