### PR TITLE
feat: expose conversion maturity and outcome coverage

### DIFF
--- a/inc/Commands/Analytics/ConversionCommand.php
+++ b/inc/Commands/Analytics/ConversionCommand.php
@@ -59,6 +59,13 @@ class ConversionCommand {
 	 * default: 1
 	 * ---
 	 *
+	 * [--return-observation-days=<days>]
+	 * : Minimum completed days after an entry journey before it enters the
+	 * denominator. Excludes late-window entries with unequal return opportunity.
+	 * ---
+	 * default: 7
+	 * ---
+	 *
 	 * [--by=<dimension>]
 	 * : Which ranking to print in table mode.
 	 * ---
@@ -83,6 +90,7 @@ class ConversionCommand {
 	 *     wp extrachill analytics conversion
 	 *     wp extrachill analytics conversion --by=article --top-articles=40
 	 *     wp extrachill analytics conversion --days=90 --min-entry-sessions=10
+	 *     wp extrachill analytics conversion --return-observation-days=14
 	 *     wp extrachill analytics conversion --format=json
 	 *
 	 * ## NOTES
@@ -101,19 +109,21 @@ class ConversionCommand {
 			WP_CLI::error( 'extrachill/get-conversion-map ability not found. Is extrachill-analytics active?' );
 		}
 
-		$days               = max( 1, (int) ( $assoc_args['days'] ?? 28 ) );
-		$session_gap_mins   = max( 1, (int) ( $assoc_args['session-gap-mins'] ?? 30 ) );
-		$top_articles       = max( 1, (int) ( $assoc_args['top-articles'] ?? 25 ) );
-		$min_entry_sessions = max( 1, (int) ( $assoc_args['min-entry-sessions'] ?? 1 ) );
-		$by                 = $assoc_args['by'] ?? 'category';
-		$format             = $assoc_args['format'] ?? 'table';
+		$days                    = max( 1, (int) ( $assoc_args['days'] ?? 28 ) );
+		$session_gap_mins        = max( 1, (int) ( $assoc_args['session-gap-mins'] ?? 30 ) );
+		$top_articles            = max( 1, (int) ( $assoc_args['top-articles'] ?? 25 ) );
+		$min_entry_sessions      = max( 1, (int) ( $assoc_args['min-entry-sessions'] ?? 1 ) );
+		$return_observation_days = max( 0, (int) ( $assoc_args['return-observation-days'] ?? 7 ) );
+		$by                      = $assoc_args['by'] ?? 'category';
+		$format                  = $assoc_args['format'] ?? 'table';
 
 		$result = $ability->execute(
 			array(
 				'days'               => $days,
 				'session_gap_mins'   => $session_gap_mins,
 				'top_articles'       => $top_articles,
-				'min_entry_sessions' => $min_entry_sessions,
+				'min_entry_sessions'      => $min_entry_sessions,
+				'return_observation_days' => $return_observation_days,
 			)
 		);
 
@@ -143,10 +153,11 @@ class ConversionCommand {
 		}
 		WP_CLI::log(
 			sprintf(
-				'Entry: blog %d editorial articles → platform surfaces %s. Session gap: %dm.',
+				'Entry: blog %d editorial articles → platform surfaces %s. Session gap: %dm. Return observation: %d completed days.',
 				(int) ( $result['entry_blog_id'] ?? 1 ),
 				wp_json_encode( $result['platform_blogs'] ?? array() ),
-				$session_gap_mins
+				$session_gap_mins,
+				(int) ( $result['return_observation_days'] ?? $return_observation_days )
 			)
 		);
 		WP_CLI::log( str_repeat( '─', 72 ) );
@@ -181,6 +192,7 @@ class ConversionCommand {
 		WP_CLI::log( sprintf( 'Returned (2nd session):  %s%%', $this->pct( $overall['returned_rate'] ?? 0 ) ) );
 
 		WP_CLI::log( '' );
+		$this->display_outcomes( (array) ( $result['outcomes'] ?? array() ) );
 
 		if ( 'article' === $by ) {
 			WP_CLI::log( sprintf( 'Top %d entry articles (by entry sessions):', $top_articles ) );
@@ -204,6 +216,79 @@ class ConversionCommand {
 			WP_CLI::log( '' );
 			WP_CLI::log( $result['note'] );
 		}
+	}
+
+	/**
+	 * Render outcome attribution without combining its independent lenses.
+	 *
+	 * @param array $outcomes Ability outcome envelope.
+	 * @return void
+	 */
+	private function display_outcomes( array $outcomes ) {
+		$overall = (array) ( $outcomes['overall'] ?? array() );
+		$coverage = (array) ( $outcomes['coverage'] ?? array() );
+
+		if ( empty( $overall ) ) {
+			return;
+		}
+
+		$event_rows   = array();
+		$direct_rows  = array();
+		$journey_rows = array();
+
+		foreach ( $overall as $type => $attribution ) {
+			$type_coverage = (array) ( $coverage[ $type ] ?? array() );
+			$direct        = (array) ( $attribution['direct_source'] ?? array() );
+			$journey       = (array) ( $attribution['visitor_journey'] ?? array() );
+			$outcome       = str_replace( '_', ' ', (string) $type );
+
+			$event_rows[] = array(
+				'outcome'       => $outcome,
+				'stored'        => $this->count( $type_coverage['stored_events'] ?? 0 ),
+				'auto_excluded' => $this->count( $type_coverage['automatic_registration_excluded'] ?? 0 ),
+				'deduplicated'  => $this->count( $type_coverage['deduplicated_outcomes'] ?? 0 ),
+				'duplicates'    => $this->count( $type_coverage['duplicate_events'] ?? 0 ),
+			);
+			$direct_rows[] = array(
+				'outcome'           => $outcome,
+				'count'             => $this->count( $direct['count'] ?? null ),
+				'coverage'          => (string) ( $direct['coverage_status'] ?? 'unknown' ),
+				'with_source'       => $this->count( $type_coverage['with_source_url'] ?? 0 ),
+				'attributed'        => $this->count( $type_coverage['direct_source_attributed'] ?? 0 ),
+				'missing_source'    => $this->count( $type_coverage['missing_source_url'] ?? 0 ),
+				'unresolved_source' => $this->count( $type_coverage['unresolved_source_url'] ?? 0 ),
+			);
+			$journey_rows[] = array(
+				'outcome'            => $outcome,
+				'same_session'       => $this->count( $journey['same_session_count'] ?? null ),
+				'later_session'      => $this->count( $journey['later_session_count'] ?? null ),
+				'coverage'           => (string) ( $journey['coverage_status'] ?? 'unknown' ),
+				'with_identity'      => $this->count( $type_coverage['with_visitor_identity'] ?? 0 ),
+				'attributed'         => $this->count( $type_coverage['visitor_journey_attributed'] ?? 0 ),
+				'missing_identity'   => $this->count( $type_coverage['missing_visitor_identity'] ?? 0 ),
+				'no_entry_journey'   => $this->count( $type_coverage['identity_without_eligible_journey'] ?? 0 ),
+				'before_entry'       => $this->count( $type_coverage['outcome_before_entry'] ?? 0 ),
+			);
+		}
+
+		WP_CLI::log( 'Outcome event coverage (before attribution):' );
+		Utils\format_items( 'table', $event_rows, array( 'outcome', 'stored', 'auto_excluded', 'deduplicated', 'duplicates' ) );
+		WP_CLI::log( 'Direct-source lens (source URL resolves to a published entry article):' );
+		Utils\format_items( 'table', $direct_rows, array( 'outcome', 'count', 'coverage', 'with_source', 'attributed', 'missing_source', 'unresolved_source' ) );
+		WP_CLI::log( 'Visitor-journey lens (identified outcome follows a mature entry journey):' );
+		Utils\format_items( 'table', $journey_rows, array( 'outcome', 'same_session', 'later_session', 'coverage', 'with_identity', 'attributed', 'missing_identity', 'no_entry_journey', 'before_entry' ) );
+		WP_CLI::log( 'Lens counts are independent and may describe the same outcome; do not add them as unique people.' );
+		WP_CLI::log( '' );
+	}
+
+	/**
+	 * Format an outcome count for human display.
+	 *
+	 * @param mixed $value Count or null when the lens is not instrumented.
+	 * @return string
+	 */
+	private function count( $value ) {
+		return null === $value ? 'n/a' : number_format( (int) $value );
 	}
 
 	/**

--- a/tests/ConversionCommandTest.php
+++ b/tests/ConversionCommandTest.php
@@ -25,12 +25,14 @@ namespace {
 
 	class ConversionCommandTestAbility {
 		public $result;
+		public $inputs = array();
 
 		public function __construct( $result ) {
 			$this->result = $result;
 		}
 
 		public function execute( $input ) {
+			$this->inputs[] = $input;
 			return $this->result;
 		}
 	}
@@ -68,12 +70,53 @@ namespace {
 		),
 		'by_category'    => array(),
 		'outcomes'       => array(
-			'overall'               => array( 'newsletter_signup' => array( 'count' => 12, 'rate' => 0.0097 ) ),
-			'by_article'            => array( array( 'post_id' => 173, 'newsletter_signup' => array( 'count' => 4, 'rate' => 0.0032 ) ) ),
+			'overall'               => array(
+				'newsletter_signup' => array(
+					'direct_source'   => array( 'count' => 12, 'coverage_status' => 'partial' ),
+					'visitor_journey' => array( 'same_session_count' => 3, 'later_session_count' => 4, 'coverage_status' => 'measured' ),
+				),
+				'user_registration' => array(
+					'direct_source'   => array( 'count' => null, 'coverage_status' => 'not_instrumented' ),
+					'visitor_journey' => array( 'same_session_count' => 1, 'later_session_count' => 2, 'coverage_status' => 'partial' ),
+				),
+			),
+			'by_article'            => array(),
 			'by_category'           => array(),
-			'coverage'              => array( 'identified_visitors' => 0.82, 'newsletter_events' => 0.76 ),
-			'attribution_semantics' => array( 'direct_source' => 'Entry article was the direct source.' ),
+			'coverage'              => array(
+				'newsletter_signup' => array(
+					'stored_events'                     => 20,
+					'automatic_registration_excluded'   => 1,
+					'deduplicated_outcomes'             => 18,
+					'duplicate_events'                  => 1,
+					'with_source_url'                   => 15,
+					'direct_source_attributed'          => 12,
+					'missing_source_url'                => 3,
+					'unresolved_source_url'             => 3,
+					'with_visitor_identity'             => 18,
+					'missing_visitor_identity'          => 0,
+					'visitor_journey_attributed'        => 7,
+					'identity_without_eligible_journey' => 10,
+					'outcome_before_entry'              => 1,
+				),
+				'user_registration' => array(
+					'stored_events'                     => 5,
+					'automatic_registration_excluded'   => 0,
+					'deduplicated_outcomes'             => 5,
+					'duplicate_events'                  => 0,
+					'with_source_url'                   => 0,
+					'direct_source_attributed'          => 0,
+					'missing_source_url'                => 5,
+					'unresolved_source_url'             => 0,
+					'with_visitor_identity'             => 4,
+					'missing_visitor_identity'          => 1,
+					'visitor_journey_attributed'        => 3,
+					'identity_without_eligible_journey' => 1,
+					'outcome_before_entry'              => 0,
+				),
+			),
+			'attribution_semantics' => 'The lenses are independent and may both attribute one outcome.',
 		),
+		'return_observation_days' => 14,
 		'future_metric'  => array( 'count' => 7, 'rate' => 0.5 ),
 	);
 
@@ -97,6 +140,12 @@ namespace {
 			throw new RuntimeException( $message . '\nExpected: ' . var_export( $expected, true ) . '\nActual: ' . var_export( $actual, true ) );
 		}
 	}
+
+	function conversion_command_test_assert_contains( $needle, $haystack, $message ) {
+		if ( false === strpos( $haystack, $needle ) ) {
+			throw new RuntimeException( $message . '\nMissing: ' . $needle );
+		}
+	}
 }
 
 namespace WP_CLI\Utils {
@@ -116,10 +165,22 @@ namespace {
 	global $conversion_command_test_formats, $conversion_command_test_result;
 
 	$command = new ConversionCommand();
-	$command( array(), array( 'by' => 'article', 'format' => 'json' ) );
+	$command( array(), array( 'by' => 'article', 'format' => 'json', 'return-observation-days' => '14' ) );
+	conversion_command_test_assert_same(
+		array(
+			'days'                    => 28,
+			'session_gap_mins'        => 30,
+			'top_articles'            => 25,
+			'min_entry_sessions'      => 1,
+			'return_observation_days' => 14,
+		),
+		$conversion_command_test_ability->inputs[0],
+		'CLI arguments must map to the owning ability contract.'
+	);
 	conversion_command_test_assert_same( $conversion_command_test_result, WP_CLI::$printed[0]['value'], 'JSON must preserve the complete typed ability result.' );
 	conversion_command_test_assert_same( array( 'format' => 'json' ), WP_CLI::$printed[0]['args'], 'JSON must use WP-CLI structured output.' );
-	conversion_command_test_assert_same( 0.82, WP_CLI::$printed[0]['value']['outcomes']['coverage']['identified_visitors'], 'JSON must retain outcome coverage.' );
+	conversion_command_test_assert_same( 12, WP_CLI::$printed[0]['value']['outcomes']['overall']['newsletter_signup']['direct_source']['count'], 'JSON outcome counts must remain numeric.' );
+	conversion_command_test_assert_same( 20, WP_CLI::$printed[0]['value']['outcomes']['coverage']['newsletter_signup']['stored_events'], 'JSON coverage counts must remain numeric.' );
 	conversion_command_test_assert_same( $conversion_command_test_result['future_metric'], WP_CLI::$printed[0]['value']['future_metric'], 'JSON must retain newly added ability fields without presenter changes.' );
 
 	$command( array(), array( 'by' => 'article', 'format' => 'csv' ) );
@@ -131,11 +192,31 @@ namespace {
 	conversion_command_test_assert_same( $conversion_command_test_result['outcomes'], json_decode( $csv['items'][0]['outcomes'], true ), 'CSV must preserve the complete outcomes envelope as JSON.' );
 	conversion_command_test_assert_same( $conversion_command_test_result['future_metric'], json_decode( $csv['items'][0]['future_metric'], true ), 'CSV must preserve newly added ability fields without presenter changes.' );
 
-	$table = $conversion_command_test_formats[1];
+	conversion_command_test_assert_same( 7, $conversion_command_test_ability->inputs[1]['return_observation_days'], 'Default return observation days must match the ability default.' );
+
+	$event_coverage = $conversion_command_test_formats[1];
+	conversion_command_test_assert_same( array( 'outcome', 'stored', 'auto_excluded', 'deduplicated', 'duplicates' ), $event_coverage['fields'], 'Human output must expose outcome event coverage.' );
+	conversion_command_test_assert_same( '20', $event_coverage['items'][0]['stored'], 'Human coverage counts must be formatted for display.' );
+
+	$direct = $conversion_command_test_formats[2];
+	conversion_command_test_assert_same( array( 'outcome', 'count', 'coverage', 'with_source', 'attributed', 'missing_source', 'unresolved_source' ), $direct['fields'], 'Direct-source output must expose source coverage.' );
+	conversion_command_test_assert_same( 'partial', $direct['items'][0]['coverage'], 'Direct-source output must identify partial coverage.' );
+	conversion_command_test_assert_same( 'n/a', $direct['items'][1]['count'], 'Not-instrumented outcome counts must not be rendered as zero.' );
+
+	$journey = $conversion_command_test_formats[3];
+	conversion_command_test_assert_same( array( 'outcome', 'same_session', 'later_session', 'coverage', 'with_identity', 'attributed', 'missing_identity', 'no_entry_journey', 'before_entry' ), $journey['fields'], 'Visitor-journey output must expose identity and journey coverage.' );
+	conversion_command_test_assert_same( '3', $journey['items'][0]['same_session'], 'Visitor-journey output must retain same-session attribution.' );
+	conversion_command_test_assert_same( '4', $journey['items'][0]['later_session'], 'Visitor-journey output must retain later-session attribution.' );
+
+	$table = $conversion_command_test_formats[4];
 	conversion_command_test_assert_same( array( 'title', 'entry_sessions', 'same_any', 'return_any', 'returned', 'reached_any' ), $table['fields'], 'Table columns must remain backward compatible.' );
 	conversion_command_test_assert_same( 'Mama Say Mama Sa Mama Coosa: The Story Behind an Iconic…', $table['items'][0]['title'], 'Table titles must retain compact display truncation.' );
 	conversion_command_test_assert_same( '1,234', $table['items'][0]['entry_sessions'], 'Table counts must retain human formatting.' );
 	conversion_command_test_assert_same( '26.0%', $table['items'][0]['reached_any'], 'Table rates must retain percentage formatting.' );
+	conversion_command_test_assert_contains( 'Return observation: 14 completed days.', implode( "\n", WP_CLI::$messages ), 'Human output must disclose conversion maturity.' );
+	conversion_command_test_assert_contains( 'Direct-source lens', implode( "\n", WP_CLI::$messages ), 'Human output must label direct-source attribution.' );
+	conversion_command_test_assert_contains( 'Visitor-journey lens', implode( "\n", WP_CLI::$messages ), 'Human output must label visitor-journey attribution.' );
+	conversion_command_test_assert_contains( 'do not add them as unique people', implode( "\n", WP_CLI::$messages ), 'Human output must explain that attribution lenses overlap.' );
 
 	fwrite( STDOUT, "ConversionCommand tests passed.\n" );
 }


### PR DESCRIPTION
## Summary
- map `--return-observation-days` to the owning ability's `return_observation_days` input, preserving its 7-day default and allowing 0
- disclose the completed return-observation window and render existing outcome event coverage in human table mode
- render direct-source and visitor-journey attribution as separate, clearly labeled lenses with their existing lens-specific coverage counters
- preserve the complete ability response for JSON and CSV without converting machine-readable numeric values to display strings

## Contract

### Argument mapping

`--return-observation-days=<days>` forwards as `return_observation_days`. The CLI clamps the value to the ability's supported non-negative range and defaults to 7, matching the owning contract.

### Human output

Table mode now shows:
- conversion maturity as the number of completed return-observation days
- shared stored-event, exclusion, deduplication, and duplicate coverage
- direct-source counts and source URL coverage
- visitor-journey same-session/later-session counts and visitor identity/journey coverage

A `not_instrumented` null count is displayed as `n/a`, rather than a measured zero.

### Attribution semantics

The direct-source lens resolves an outcome event's `source_url` to a published main-site entry article. The visitor-journey lens attributes an identified outcome after that visitor's first eligible mature entry journey and preserves the ability's same-session versus later-session split. These lenses are independent and may describe the same outcome, so the human presenter explicitly warns against adding them as unique people.

### Coverage and JSON compatibility

The CLI only presents coverage already calculated by `extrachill/get-conversion-map`; it does not duplicate report calculations or introduce broader lifecycle outcomes. JSON continues to pass the complete typed ability envelope directly to `WP_CLI::print_value()`, including future top-level fields, nested attribution, coverage statuses, and numeric counts. CSV continues to retain every top-level field and JSON-encode nested values.

## Verification
- `php tests/ConversionCommandTest.php`
- all standalone tests: `OutboundCommandTest.php`, `RevenueCommandRuntimeTest.php`, `RevenueCommandTest.php`, `UserLocalSceneCommandTest.php`, `ConversionCommandTest.php`, `QRCodeCommandTest.php`, `SummaryCommandTest.php`, `RetentionCommandTest.php`, `CrosslinkTargetsCommandTest.php`
- `php -l inc/Commands/Analytics/ConversionCommand.php`
- `php -l tests/ConversionCommandTest.php`
- `phpcs --standard=WordPress inc/Commands/Analytics/ConversionCommand.php tests/ConversionCommandTest.php`
- `git diff --check`

Closes #109