### PR TITLE
feat: expose first-party route transitions

### DIFF
--- a/homeboy.json
+++ b/homeboy.json
@@ -12,6 +12,7 @@
       "php tests/CrosslinkTargetsCommandTest.php",
       "php tests/OutboundCommandTest.php",
       "php tests/ConversionCommandTest.php",
+      "php tests/RouteTransitionsCommandTest.php",
       "php tests/SummaryCommandTest.php",
       "php tests/RetentionCommandTest.php",
       "php tests/UserLocalSceneCommandTest.php",

--- a/inc/CommandRegistry.php
+++ b/inc/CommandRegistry.php
@@ -48,6 +48,7 @@ class CommandRegistry {
 			'extrachill analytics growth'            => Commands\Analytics\GrowthCommand::class,
 			'extrachill analytics demand-drill'      => Commands\Analytics\DemandDrillCommand::class,
 			'extrachill analytics conversion'        => Commands\Analytics\ConversionCommand::class,
+			'extrachill analytics route-transitions' => Commands\Analytics\RouteTransitionsCommand::class,
 			'extrachill analytics crosslink-targets' => Commands\Analytics\CrosslinkTargetsCommand::class,
 			'extrachill analytics outbound'          => Commands\Analytics\OutboundCommand::class,
 			'extrachill analytics stickiness'        => Commands\Analytics\StickinessCommand::class,

--- a/inc/Commands/Analytics/RouteTransitionsCommand.php
+++ b/inc/Commands/Analytics/RouteTransitionsCommand.php
@@ -1,0 +1,376 @@
+<?php
+/**
+ * Analytics Route Transitions CLI Command
+ *
+ * Thin presenter for the extrachill/get-route-transitions ability.
+ *
+ * @package ExtraChill\CLI\Commands\Analytics
+ */
+
+namespace ExtraChill\CLI\Commands\Analytics;
+
+use WP_CLI;
+use WP_CLI\Utils;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+class RouteTransitionsCommand {
+
+	/**
+	 * Show first-party same-session route transitions.
+	 *
+	 * Reports adjacent route transitions, session entries and terminals, and
+	 * exact-length ordered sequences from identified, bot-filtered pageviews.
+	 * Route identity is the owning ability's (blog_id, route_family) pair.
+	 *
+	 * ## OPTIONS
+	 *
+	 * [--days=<days>]
+	 * : UTC lookback days. Accepted range: 1-90.
+	 * ---
+	 * default: 28
+	 * ---
+	 *
+	 * [--blog-id=<id>]
+	 * : Filter to one blog ID. Zero reports the network.
+	 * ---
+	 * default: 0
+	 * ---
+	 *
+	 * [--session-gap-mins=<mins>]
+	 * : Inactivity gap that ends a session. Accepted range: 1-120.
+	 * ---
+	 * default: 30
+	 * ---
+	 *
+	 * [--sequence-length=<length>]
+	 * : Exact number of route observations per sequence. Accepted range: 2-5.
+	 * ---
+	 * default: 3
+	 * ---
+	 *
+	 * [--cohort=<cohort>]
+	 * : Session-entry acquisition cohort.
+	 * ---
+	 * default: all
+	 * options:
+	 *   - all
+	 *   - first_time
+	 *   - returning
+	 * ---
+	 *
+	 * [--limit=<limit>]
+	 * : Maximum rows in each ranking. Accepted range: 1-100.
+	 * ---
+	 * default: 25
+	 * ---
+	 *
+	 * [--max-pageviews=<count>]
+	 * : Maximum identified pageviews loaded. Accepted range: 100-25000.
+	 * ---
+	 * default: 10000
+	 * ---
+	 *
+	 * [--format=<format>]
+	 * : Output format. JSON and CSV preserve the complete ability envelope.
+	 * ---
+	 * default: table
+	 * options:
+	 *   - table
+	 *   - json
+	 *   - csv
+	 * ---
+	 *
+	 * ## EXAMPLES
+	 *
+	 *     wp extrachill analytics route-transitions
+	 *     wp extrachill analytics route-transitions --cohort=first_time
+	 *     wp extrachill analytics route-transitions --sequence-length=5 --limit=50
+	 *     wp extrachill analytics route-transitions --blog-id=7 --format=json
+	 *
+	 * ## NOTES
+	 *
+	 * This command delegates sessionization, acquisition cohorts, ranking, and
+	 * coverage semantics to extrachill/get-route-transitions. It takes no acting
+	 * user context; omit the global `--user` flag.
+	 *
+	 * @subcommand __default
+	 * @when after_wp_load
+	 */
+	public function __invoke( $args, $assoc_args ) {
+		$ability = wp_get_ability( 'extrachill/get-route-transitions' );
+
+		if ( ! $ability ) {
+			WP_CLI::error( 'extrachill/get-route-transitions ability not found. Is extrachill-analytics active?' );
+		}
+
+		$input  = array(
+			'days'             => (int) ( $assoc_args['days'] ?? 28 ),
+			'blog_id'          => (int) ( $assoc_args['blog-id'] ?? 0 ),
+			'session_gap_mins' => (int) ( $assoc_args['session-gap-mins'] ?? 30 ),
+			'sequence_length'  => (int) ( $assoc_args['sequence-length'] ?? 3 ),
+			'cohort'           => (string) ( $assoc_args['cohort'] ?? 'all' ),
+			'limit'            => (int) ( $assoc_args['limit'] ?? 25 ),
+			'max_pageviews'    => (int) ( $assoc_args['max-pageviews'] ?? 10000 ),
+		);
+		$format = $assoc_args['format'] ?? 'table';
+		$result = $ability->execute( $input );
+
+		if ( is_wp_error( $result ) ) {
+			WP_CLI::error( $result->get_error_message() );
+		}
+
+		if ( 'json' === $format ) {
+			WP_CLI::print_value( $result, array( 'format' => 'json' ) );
+			return;
+		}
+
+		if ( 'csv' === $format ) {
+			Utils\format_items( 'csv', array( $this->csv_row( $result ) ), array_keys( $result ) );
+			return;
+		}
+
+		$this->display_table( $result );
+	}
+
+	/**
+	 * Render the human report without recalculating ability metrics.
+	 *
+	 * @param array $result Ability result.
+	 * @return void
+	 */
+	private function display_table( array $result ) {
+		$bounds   = (array) ( $result['bounds'] ?? array() );
+		$period   = (array) ( $result['period'] ?? array() );
+		$counts   = (array) ( $result['counts'] ?? array() );
+		$coverage = (array) ( $result['coverage'] ?? array() );
+
+		WP_CLI::log( 'First-Party Route Transitions' );
+		WP_CLI::log(
+			sprintf(
+				'Window (UTC): %s to %s; rankings since %s',
+				$period['since'] ?? 'unavailable',
+				$period['until'] ?? 'unavailable',
+				$period['ranking_since'] ?? 'unavailable'
+			)
+		);
+		WP_CLI::log(
+			sprintf(
+				'Scope: blog %s; cohort %s; session gap %sm; sequence length %s; row limit %s; pageview cap %s',
+				0 === (int) ( $bounds['blog_id'] ?? 0 ) ? 'network' : (string) $bounds['blog_id'],
+				$bounds['cohort'] ?? 'all',
+				$bounds['session_gap_mins'] ?? 'unavailable',
+				$bounds['sequence_length'] ?? 'unavailable',
+				$bounds['limit'] ?? 'unavailable',
+				$bounds['max_pageviews'] ?? 'unavailable'
+			)
+		);
+		WP_CLI::log( str_repeat( '-', 72 ) );
+
+		$this->display_coverage( $coverage, $counts );
+		$this->display_rankings( $result );
+
+		if ( ! empty( $result['note'] ) ) {
+			WP_CLI::log( '' );
+			WP_CLI::log( $result['note'] );
+		}
+	}
+
+	/**
+	 * Render identity, route collection, and admitted-session coverage.
+	 *
+	 * @param array $coverage Coverage envelope.
+	 * @param array $counts   Session and transition counts.
+	 * @return void
+	 */
+	private function display_coverage( array $coverage, array $counts ) {
+		$total      = (int) ( $coverage['total_pageviews'] ?? 0 );
+		$identified = (int) ( $coverage['identified_pageviews'] ?? 0 );
+		$rate       = $total > 0 ? $this->pct( $coverage['identity_coverage_rate'] ?? 0 ) : 'n/a';
+
+		WP_CLI::log( 'First-party identity and session coverage:' );
+		WP_CLI::log(
+			sprintf(
+				'Pageviews: %s total; %s identified; %s anonymous; identity coverage %s%s',
+				$this->count( $total ),
+				$this->count( $identified ),
+				$this->count( $coverage['anonymous_pageviews'] ?? 0 ),
+				$rate,
+				'n/a' === $rate ? ' (no pageviews in window)' : '%'
+			)
+		);
+		WP_CLI::log(
+			sprintf(
+				'Rankings: %s identified pageviews loaded; complete-window rankings: %s',
+				$this->count( $coverage['loaded_identified_pageviews'] ?? 0 ),
+				! empty( $coverage['truncated'] ) ? 'no (bounded recent sample)' : 'yes'
+			)
+		);
+		WP_CLI::log(
+			sprintf(
+				'Sessions: %s included; %s first-time; %s returning; %s one-page direct terminals',
+				$this->count( $counts['sessions'] ?? 0 ),
+				$this->count( $counts['first_time_sessions'] ?? 0 ),
+				$this->count( $counts['returning_sessions'] ?? 0 ),
+				$this->count( $counts['direct_terminal_sessions'] ?? 0 )
+			)
+		);
+
+		$rows = array(
+			array(
+				'classification' => 'explicit route family',
+				'pageviews'      => $this->count( $coverage['explicit_route_family_pageviews'] ?? 0 ),
+			),
+			array(
+				'classification' => 'historical inferred singular',
+				'pageviews'      => $this->count( $coverage['inferred_singular_pageviews'] ?? 0 ),
+			),
+			array(
+				'classification' => 'historical unclassified',
+				'pageviews'      => $this->count( $coverage['historical_unclassified_pageviews'] ?? 0 ),
+			),
+		);
+		Utils\format_items( 'table', $rows, array( 'classification', 'pageviews' ) );
+		WP_CLI::log( '' );
+	}
+
+	/**
+	 * Render all four ability rankings.
+	 *
+	 * @param array $result Ability result.
+	 * @return void
+	 */
+	private function display_rankings( array $result ) {
+		$transition_rows = array_map( array( $this, 'transition_row' ), (array) ( $result['transitions'] ?? array() ) );
+		$this->display_section(
+			'Transitions:',
+			$transition_rows,
+			array( 'from_blog', 'from_route', 'to_blog', 'to_route', 'surface', 'count' ),
+			'no same-session transitions available for this scope'
+		);
+
+		$entry_rows = array_map( array( $this, 'route_row' ), (array) ( $result['entries'] ?? array() ) );
+		$this->display_section( 'Session entries:', $entry_rows, array( 'blog_id', 'route_family', 'count' ), 'no session entries available for this scope' );
+
+		$terminal_rows = array_map( array( $this, 'route_row' ), (array) ( $result['terminals'] ?? array() ) );
+		$this->display_section( 'Session terminals:', $terminal_rows, array( 'blog_id', 'route_family', 'count' ), 'no session terminals available for this scope' );
+
+		$sequence_rows = array_map( array( $this, 'sequence_row' ), (array) ( $result['sequences'] ?? array() ) );
+		$this->display_section( 'Ordered sequences:', $sequence_rows, array( 'path', 'count' ), 'no complete ordered sequences available for this scope and sequence length' );
+	}
+
+	/**
+	 * Render one ranking or its honest empty state.
+	 *
+	 * @param string $label   Section label.
+	 * @param array  $rows    Display rows.
+	 * @param array  $columns Display columns.
+	 * @param string $empty_state Empty-state explanation.
+	 * @return void
+	 */
+	private function display_section( $label, array $rows, array $columns, $empty_state ) {
+		WP_CLI::log( $label );
+		if ( empty( $rows ) ) {
+			WP_CLI::log( "  ({$empty_state})" );
+			WP_CLI::log( '' );
+			return;
+		}
+
+		Utils\format_items( 'table', $rows, $columns );
+		WP_CLI::log( '' );
+	}
+
+	/**
+	 * Build one transition display row.
+	 *
+	 * @param array $row Ability transition row.
+	 * @return array<string,string>
+	 */
+	private function transition_row( $row ) {
+		$from = (array) ( $row['from'] ?? array() );
+		$to   = (array) ( $row['to'] ?? array() );
+
+		return array(
+			'from_blog'  => (string) ( $from['blog_id'] ?? '' ),
+			'from_route' => (string) ( $from['route_family'] ?? '' ),
+			'to_blog'    => (string) ( $to['blog_id'] ?? '' ),
+			'to_route'   => (string) ( $to['route_family'] ?? '' ),
+			'surface'    => ! empty( $row['same_surface'] ) ? 'same' : 'cross',
+			'count'      => $this->count( $row['count'] ?? 0 ),
+		);
+	}
+
+	/**
+	 * Build one entry or terminal display row.
+	 *
+	 * @param array $row Ability route row.
+	 * @return array<string,string>
+	 */
+	private function route_row( $row ) {
+		$route = (array) ( $row['route'] ?? array() );
+
+		return array(
+			'blog_id'      => (string) ( $route['blog_id'] ?? '' ),
+			'route_family' => (string) ( $route['route_family'] ?? '' ),
+			'count'        => $this->count( $row['count'] ?? 0 ),
+		);
+	}
+
+	/**
+	 * Build one ordered sequence display row.
+	 *
+	 * @param array $row Ability sequence row.
+	 * @return array<string,string>
+	 */
+	private function sequence_row( $row ) {
+		$nodes = array_map(
+			static function ( $node ) {
+				return (int) ( $node['blog_id'] ?? 0 ) . ':' . (string) ( $node['route_family'] ?? '' );
+			},
+			(array) ( $row['path'] ?? array() )
+		);
+
+		return array(
+			'path'  => implode( ' -> ', $nodes ),
+			'count' => $this->count( $row['count'] ?? 0 ),
+		);
+	}
+
+	/**
+	 * Preserve the complete response envelope in one deterministic CSV row.
+	 *
+	 * @param array $result Ability result.
+	 * @return array<string,mixed>
+	 */
+	private function csv_row( array $result ) {
+		foreach ( $result as $key => $value ) {
+			if ( is_array( $value ) || is_object( $value ) ) {
+				$result[ $key ] = wp_json_encode( $value );
+			}
+		}
+
+		return $result;
+	}
+
+	/**
+	 * Format a count for human output.
+	 *
+	 * @param mixed $value Count.
+	 * @return string
+	 */
+	private function count( $value ) {
+		return number_format( (int) $value );
+	}
+
+	/**
+	 * Format a 0..1 rate as a percentage without its suffix.
+	 *
+	 * @param mixed $value Rate.
+	 * @return string
+	 */
+	private function pct( $value ) {
+		return number_format( (float) $value * 100, 1 );
+	}
+}

--- a/tests/RouteTransitionsCommandTest.php
+++ b/tests/RouteTransitionsCommandTest.php
@@ -1,0 +1,239 @@
+<?php
+/**
+ * Focused contract, machine-output, and presenter tests for route transitions.
+ */
+
+namespace {
+	define( 'ABSPATH', __DIR__ . '/' );
+
+	class WP_CLI {
+		public static $messages = array();
+		public static $printed  = array();
+
+		public static function error( $message ) {
+			throw new RuntimeException( $message );
+		}
+
+		public static function log( $message ) {
+			self::$messages[] = $message;
+		}
+
+		public static function print_value( $value, $args ) {
+			self::$printed[] = compact( 'value', 'args' );
+		}
+	}
+
+	class RouteTransitionsCommandTestAbility {
+		public $inputs = array();
+		public $result;
+
+		public function __construct( $result ) {
+			$this->result = $result;
+		}
+
+		public function execute( $input ) {
+			$this->inputs[] = $input;
+			return $this->result;
+		}
+	}
+
+	$route_transitions_command_test_result = array(
+		'counts'      => array(
+			'sessions'                  => 1234,
+			'first_time_sessions'       => 700,
+			'returning_sessions'        => 534,
+			'direct_terminal_sessions'  => 400,
+			'transitions'               => 2000,
+			'same_surface_transitions'  => 1500,
+			'cross_surface_transitions' => 500,
+			'sequence_windows'          => 900,
+		),
+		'transitions' => array(
+			array(
+				'from'         => array( 'blog_id' => 1, 'route_family' => 'singular' ),
+				'to'           => array( 'blog_id' => 7, 'route_family' => 'home' ),
+				'count'        => 1234,
+				'same_surface' => false,
+			),
+		),
+		'sequences'   => array(
+			array(
+				'path'  => array(
+					array( 'blog_id' => 1, 'route_family' => 'singular' ),
+					array( 'blog_id' => 7, 'route_family' => 'home' ),
+					array( 'blog_id' => 7, 'route_family' => 'singular' ),
+				),
+				'count' => 321,
+			),
+		),
+		'entries'     => array(
+			array( 'route' => array( 'blog_id' => 1, 'route_family' => 'singular' ), 'count' => 1000 ),
+		),
+		'terminals'   => array(
+			array( 'route' => array( 'blog_id' => 7, 'route_family' => 'singular' ), 'count' => 800 ),
+		),
+		'definitions' => array( 'transition' => 'Every adjacent pair.' ),
+		'coverage'    => array(
+			'total_pageviews'                   => 5000,
+			'identified_pageviews'              => 4000,
+			'anonymous_pageviews'               => 1000,
+			'identity_coverage_rate'            => 0.8,
+			'explicit_route_family_pageviews'   => 3500,
+			'inferred_singular_pageviews'       => 1000,
+			'historical_unclassified_pageviews' => 500,
+			'loaded_identified_pageviews'       => 4000,
+			'truncated'                         => false,
+			'definition'                        => 'Identity and route classification coverage.',
+		),
+		'bounds'      => array(
+			'days'             => 28,
+			'blog_id'          => 0,
+			'session_gap_mins' => 30,
+			'sequence_length'  => 3,
+			'cohort'           => 'all',
+			'limit'            => 25,
+			'max_pageviews'    => 10000,
+		),
+		'period'      => array(
+			'since'         => '2026-06-19 00:00:00',
+			'ranking_since' => '2026-06-19 00:00:00',
+			'until'         => '2026-07-17 00:00:00',
+			'as_of'         => '2026-07-17 00:00:00',
+		),
+		'note'          => 'Deterministic and bot-filtered by the existing pageview writer.',
+		'future_metric' => array( 'count' => 7, 'rate' => 0.5 ),
+	);
+	$route_transitions_command_test_ability = new RouteTransitionsCommandTestAbility( $route_transitions_command_test_result );
+
+	function wp_get_ability( $name ) {
+		global $route_transitions_command_test_ability;
+		return 'extrachill/get-route-transitions' === $name ? $route_transitions_command_test_ability : null;
+	}
+
+	function is_wp_error( $value ) {
+		return false;
+	}
+
+	function wp_json_encode( $value ) {
+		return json_encode( $value );
+	}
+
+	function route_transitions_command_test_assert_same( $expected, $actual, $message ) {
+		if ( $expected !== $actual ) {
+			throw new RuntimeException( $message . '\nExpected: ' . var_export( $expected, true ) . '\nActual: ' . var_export( $actual, true ) );
+		}
+	}
+
+	function route_transitions_command_test_assert_contains( $needle, $haystack, $message ) {
+		if ( false === strpos( $haystack, $needle ) ) {
+			throw new RuntimeException( $message . '\nMissing: ' . $needle );
+		}
+	}
+}
+
+namespace WP_CLI\Utils {
+	$route_transitions_command_test_formats = array();
+
+	function format_items( $format, $items, $fields ) {
+		global $route_transitions_command_test_formats;
+		$route_transitions_command_test_formats[] = compact( 'format', 'items', 'fields' );
+	}
+}
+
+namespace {
+	require_once dirname( __DIR__ ) . '/inc/Commands/Analytics/RouteTransitionsCommand.php';
+
+	use ExtraChill\CLI\Commands\Analytics\RouteTransitionsCommand;
+
+	global $route_transitions_command_test_ability, $route_transitions_command_test_formats, $route_transitions_command_test_result;
+
+	$command = new RouteTransitionsCommand();
+	$command(
+		array(),
+		array(
+			'days'             => '90',
+			'blog-id'          => '7',
+			'session-gap-mins' => '120',
+			'sequence-length'  => '5',
+			'cohort'           => 'returning',
+			'limit'            => '100',
+			'max-pageviews'    => '25000',
+			'format'           => 'json',
+		)
+	);
+	route_transitions_command_test_assert_same(
+		array(
+			'days'             => 90,
+			'blog_id'          => 7,
+			'session_gap_mins' => 120,
+			'sequence_length'  => 5,
+			'cohort'           => 'returning',
+			'limit'            => 100,
+			'max_pageviews'    => 25000,
+		),
+		$route_transitions_command_test_ability->inputs[0],
+		'Every bounded CLI filter must map exactly to the owning ability contract.'
+	);
+	route_transitions_command_test_assert_same( $route_transitions_command_test_result, WP_CLI::$printed[0]['value'], 'JSON must preserve the complete typed ability envelope.' );
+	route_transitions_command_test_assert_same( 1234, WP_CLI::$printed[0]['value']['transitions'][0]['count'], 'JSON counts must remain integers.' );
+	route_transitions_command_test_assert_same( false, WP_CLI::$printed[0]['value']['transitions'][0]['same_surface'], 'JSON booleans must remain typed.' );
+	route_transitions_command_test_assert_same( $route_transitions_command_test_result['future_metric'], WP_CLI::$printed[0]['value']['future_metric'], 'JSON must retain future ability fields.' );
+
+	$command( array(), array( 'format' => 'csv' ) );
+	$csv = $route_transitions_command_test_formats[0];
+	route_transitions_command_test_assert_same( array_keys( $route_transitions_command_test_result ), $csv['fields'], 'CSV must retain every top-level ability field.' );
+	route_transitions_command_test_assert_same( 1234, json_decode( $csv['items'][0]['transitions'], true )[0]['count'], 'CSV nested counts must remain numeric JSON values.' );
+	route_transitions_command_test_assert_same( 0.8, json_decode( $csv['items'][0]['coverage'], true )['identity_coverage_rate'], 'CSV rates must not use display-formatted strings.' );
+	route_transitions_command_test_assert_same( $route_transitions_command_test_result['future_metric'], json_decode( $csv['items'][0]['future_metric'], true ), 'CSV must retain future ability fields.' );
+	route_transitions_command_test_assert_same(
+		array(
+			'days'             => 28,
+			'blog_id'          => 0,
+			'session_gap_mins' => 30,
+			'sequence_length'  => 3,
+			'cohort'           => 'all',
+			'limit'            => 25,
+			'max_pageviews'    => 10000,
+		),
+		$route_transitions_command_test_ability->inputs[1],
+		'Default arguments must match the ability contract.'
+	);
+
+	$command( array(), array() );
+	$coverage  = $route_transitions_command_test_formats[1];
+	$transitions = $route_transitions_command_test_formats[2];
+	$entries     = $route_transitions_command_test_formats[3];
+	$terminals   = $route_transitions_command_test_formats[4];
+	$sequences   = $route_transitions_command_test_formats[5];
+	route_transitions_command_test_assert_same( array( 'classification', 'pageviews' ), $coverage['fields'], 'Human output must table route collection coverage.' );
+	route_transitions_command_test_assert_same( '3,500', $coverage['items'][0]['pageviews'], 'Human coverage counts must be display-formatted.' );
+	route_transitions_command_test_assert_same( array( 'from_blog', 'from_route', 'to_blog', 'to_route', 'surface', 'count' ), $transitions['fields'], 'Transition table must expose complete route identity.' );
+	route_transitions_command_test_assert_same( 'cross', $transitions['items'][0]['surface'], 'Transition table must distinguish cross-surface movement.' );
+	route_transitions_command_test_assert_same( array( 'blog_id', 'route_family', 'count' ), $entries['fields'], 'Entry table must expose route identity.' );
+	route_transitions_command_test_assert_same( array( 'blog_id', 'route_family', 'count' ), $terminals['fields'], 'Terminal table must expose route identity.' );
+	route_transitions_command_test_assert_same( '1:singular -> 7:home -> 7:singular', $sequences['items'][0]['path'], 'Sequence table must preserve route order and surface identity.' );
+	$messages = implode( "\n", WP_CLI::$messages );
+	route_transitions_command_test_assert_contains( 'First-party identity and session coverage:', $messages, 'Human output must identify first-party coverage.' );
+	route_transitions_command_test_assert_contains( 'identity coverage 80.0%', $messages, 'Human output must disclose identity coverage.' );
+	route_transitions_command_test_assert_contains( 'Sessions: 1,234 included; 700 first-time; 534 returning', $messages, 'Human output must disclose session cohort coverage.' );
+
+	$route_transitions_command_test_ability->result['transitions'] = array();
+	$route_transitions_command_test_ability->result['entries']     = array();
+	$route_transitions_command_test_ability->result['terminals']   = array();
+	$route_transitions_command_test_ability->result['sequences']   = array();
+	$route_transitions_command_test_ability->result['coverage']['total_pageviews']         = 0;
+	$route_transitions_command_test_ability->result['coverage']['identified_pageviews']    = 0;
+	$route_transitions_command_test_ability->result['coverage']['anonymous_pageviews']     = 0;
+	$route_transitions_command_test_ability->result['coverage']['identity_coverage_rate']  = 0.0;
+	$before = count( $route_transitions_command_test_formats );
+	$command( array(), array() );
+	route_transitions_command_test_assert_same( $before + 1, count( $route_transitions_command_test_formats ), 'Empty rankings must not emit misleading empty tables.' );
+	$empty_messages = implode( "\n", WP_CLI::$messages );
+	route_transitions_command_test_assert_contains( 'identity coverage n/a (no pageviews in window)', $empty_messages, 'Zero-data identity coverage must be unavailable rather than 0%.' );
+	route_transitions_command_test_assert_contains( '(no same-session transitions available for this scope)', $empty_messages, 'Transitions need an honest empty state.' );
+	route_transitions_command_test_assert_contains( '(no session entries available for this scope)', $empty_messages, 'Entries need an honest empty state.' );
+	route_transitions_command_test_assert_contains( '(no session terminals available for this scope)', $empty_messages, 'Terminals need an honest empty state.' );
+	route_transitions_command_test_assert_contains( '(no complete ordered sequences available for this scope and sequence length)', $empty_messages, 'Sequences need an honest empty state.' );
+
+	fwrite( STDOUT, "RouteTransitionsCommand tests passed.\n" );
+}


### PR DESCRIPTION
## Summary
- expose `wp extrachill analytics route-transitions` as a thin adapter over `extrachill/get-route-transitions`
- render first-party coverage plus transitions, session entries, session terminals, and ordered sequences for operators
- preserve the complete typed ability envelope for machine consumers

## Argument Mapping
- `--days` -> `days`
- `--blog-id` -> `blog_id`
- `--session-gap-mins` -> `session_gap_mins`
- `--sequence-length` -> `sequence_length`
- `--cohort` -> `cohort`
- `--limit` -> `limit`
- `--max-pageviews` -> `max_pageviews`
- `--format` remains presenter-only and is not passed to the ability

The CLI casts input types and delegates all clamping, sessionization, acquisition cohort classification, ranking, truncation handling, and report semantics to the owning ability.

## Human Output
- identifies the UTC report window, bounded ranking window, blog/network scope, cohort, gap, sequence length, row limit, and pageview cap
- discloses total, identified, anonymous, loaded, and truncated pageview coverage plus admitted first-time/returning sessions and direct terminals
- tables explicit route-family, historically inferred singular, and historical unclassified collection coverage
- tables A -> B transitions with both `(blog_id, route_family)` identities and same/cross-surface status
- tables session entries, session terminals, and ordered exact-length route sequences
- reports empty rankings explicitly and renders identity coverage as unavailable when the period has no pageviews

## Machine Compatibility
- JSON prints the untouched typed ability result, including future top-level fields
- CSV emits one complete envelope row, JSON-encoding nested values without display-formatting counts, rates, or booleans
- human number and percentage formatting is confined to table output

## Coverage Semantics
- route/session rankings use only first-party identified pageviews admitted by the ability
- anonymous pageviews remain visible in coverage but are not represented as sessionized journeys
- route collection distinguishes explicit write-time families, historical post-backed singular inference, and historical unclassified rows
- truncated bounded samples are labeled as incomplete-window rankings rather than complete totals

## Verification
- `php tests/RouteTransitionsCommandTest.php`
- `php tests/QRCodeCommandTest.php && php tests/CrosslinkTargetsCommandTest.php && php tests/OutboundCommandTest.php && php tests/ConversionCommandTest.php && php tests/RouteTransitionsCommandTest.php && php tests/SummaryCommandTest.php && php tests/RetentionCommandTest.php && php tests/UserLocalSceneCommandTest.php && php tests/RevenueCommandTest.php && php tests/RevenueCommandRuntimeTest.php`
- `php -l inc/Commands/Analytics/RouteTransitionsCommand.php && php -l tests/RouteTransitionsCommandTest.php && php -l inc/CommandRegistry.php`
- `homeboy review extrachill-cli lint --path /var/lib/datamachine/workspace/extrachill-cli@issue-110-route-transitions --changed-only --placement=local --summary` (PHPCS: zero findings; unrelated Homeboy PHPStan extension binary warning caused PHPStan to skip)
- `git diff --check`

Closes #110