### PR TITLE
feat: expose platform experiment operations

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,24 @@ wp plugin activate extrachill-cli --network --allow-root
 
 ## Commands
 
+### Platform Experiments
+
+Inspect registered definitions and orphaned lifecycle records, transition
+registered experiments, and request Analytics-owned experiment summaries:
+
+```bash
+wp --allow-root --path=/var/www/extrachill.com extrachill experiments list
+wp --allow-root --path=/var/www/extrachill.com extrachill experiments get geo-bridge-holdout
+wp --allow-root --path=/var/www/extrachill.com extrachill experiments state geo-bridge-holdout active
+wp --allow-root --path=/var/www/extrachill.com extrachill experiments report geo-bridge-holdout --outcome-event-types=bridge_click
+```
+
+Network authorizes these private administrative Abilities for trusted local
+WP-CLI execution. Use the standard local invocation above without `--user`.
+Web and REST contexts still require Network's administrative capability.
+Orphaned rows are inspectable through `list` and `get`, but cannot be
+transitioned or reported because they have no registered code definition.
+
 ### Tools — QR Code
 
 Generate print-ready QR code PNG files through the existing admin-tools ability primitive.

--- a/homeboy.json
+++ b/homeboy.json
@@ -9,6 +9,7 @@
   "self_checks": {
     "test": [
       "php tests/QRCodeCommandTest.php",
+      "php tests/ExperimentsCommandTest.php",
       "php tests/CrosslinkTargetsCommandTest.php",
       "php tests/OutboundCommandTest.php",
       "php tests/ConversionCommandTest.php",

--- a/homeboy.json
+++ b/homeboy.json
@@ -10,6 +10,7 @@
     "test": [
       "php tests/QRCodeCommandTest.php",
       "php tests/ExperimentsCommandTest.php",
+      "php tests/ExperimentsOwnerContractTest.php",
       "php tests/CrosslinkTargetsCommandTest.php",
       "php tests/OutboundCommandTest.php",
       "php tests/ConversionCommandTest.php",

--- a/inc/CommandRegistry.php
+++ b/inc/CommandRegistry.php
@@ -33,6 +33,7 @@ class CommandRegistry {
 		return array(
 			// Platform commands.
 			'extrachill platform'                    => Commands\Platform\HealthCommand::class,
+			'extrachill experiments'                 => Commands\Experiments\ExperimentsCommand::class,
 
 			// Network commands — thin wrappers over extrachill-multisite primitives.
 			'extrachill network'                     => Commands\Network\MigratePostCommand::class,

--- a/inc/Commands/Experiments/ExperimentsCommand.php
+++ b/inc/Commands/Experiments/ExperimentsCommand.php
@@ -1,0 +1,408 @@
+<?php
+/**
+ * Platform Experiments CLI Command
+ *
+ * Thin adapters over the Network lifecycle and Analytics report abilities.
+ *
+ * @package ExtraChill\CLI\Commands\Experiments
+ */
+
+namespace ExtraChill\CLI\Commands\Experiments;
+
+use WP_CLI;
+use WP_CLI\Utils;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+class ExperimentsCommand {
+
+	/**
+	 * List registered platform experiments.
+	 *
+	 * ## OPTIONS
+	 *
+	 * [--format=<format>]
+	 * : Output format. JSON and CSV preserve the complete owner envelope.
+	 * ---
+	 * default: table
+	 * options:
+	 *   - table
+	 *   - json
+	 *   - csv
+	 * ---
+	 *
+	 * ## EXAMPLES
+	 *
+	 *     wp extrachill experiments list
+	 *     wp extrachill experiments list --format=json
+	 *
+	 * @subcommand list
+	 * @when after_wp_load
+	 */
+	public function list_( $args, $assoc_args ) {
+		$result = $this->execute( 'extrachill/list-experiments', array(), 'Extra Chill Network' );
+		$format = $assoc_args['format'] ?? 'table';
+
+		if ( 'json' === $format ) {
+			WP_CLI::print_value( $result, array( 'format' => 'json' ) );
+			return;
+		}
+		if ( 'csv' === $format ) {
+			$this->display_csv( $result );
+			return;
+		}
+
+		if ( empty( $result ) ) {
+			WP_CLI::log( 'No registered experiments.' );
+			return;
+		}
+		foreach ( $result as $definition ) {
+			$this->display_definition( (array) $definition );
+		}
+	}
+
+	/**
+	 * Get one registered platform experiment.
+	 *
+	 * ## OPTIONS
+	 *
+	 * <key>
+	 * : Stable experiment key.
+	 *
+	 * [--format=<format>]
+	 * : Output format. JSON and CSV preserve the complete owner envelope.
+	 * ---
+	 * default: table
+	 * options:
+	 *   - table
+	 *   - json
+	 *   - csv
+	 * ---
+	 *
+	 * ## EXAMPLES
+	 *
+	 *     wp extrachill experiments get geo-bridge-holdout
+	 *     wp extrachill experiments get geo-bridge-holdout --format=json
+	 *
+	 * @when after_wp_load
+	 */
+	public function get( $args, $assoc_args ) {
+		$definition = $this->definition( $args[0] ?? '' );
+		$format     = $assoc_args['format'] ?? 'table';
+
+		if ( 'json' === $format ) {
+			WP_CLI::print_value( $definition, array( 'format' => 'json' ) );
+			return;
+		}
+		if ( 'csv' === $format ) {
+			$this->display_csv( array( $definition ) );
+			return;
+		}
+
+		$this->display_definition( $definition );
+	}
+
+	/**
+	 * Transition one experiment's current definition version.
+	 *
+	 * ## OPTIONS
+	 *
+	 * <key>
+	 * : Stable experiment key.
+	 *
+	 * <state>
+	 * : Requested lifecycle state.
+	 * ---
+	 * options:
+	 *   - inactive
+	 *   - active
+	 *   - paused
+	 *   - completed
+	 * ---
+	 *
+	 * [--yes]
+	 * : Skip confirmation when activating or completing an experiment.
+	 *
+	 * [--format=<format>]
+	 * : Output format. JSON and CSV preserve the complete before, transition, and after owner envelopes.
+	 * ---
+	 * default: table
+	 * options:
+	 *   - table
+	 *   - json
+	 *   - csv
+	 * ---
+	 *
+	 * ## EXAMPLES
+	 *
+	 *     wp extrachill experiments state geo-bridge-holdout active
+	 *     wp extrachill experiments state geo-bridge-holdout completed --yes --format=json
+	 *
+	 * @when after_wp_load
+	 */
+	public function state( $args, $assoc_args ) {
+		$key    = (string) ( $args[0] ?? '' );
+		$state  = (string) ( $args[1] ?? '' );
+		$before = $this->definition( $key );
+
+		if ( in_array( $state, array( 'active', 'completed' ), true ) ) {
+			WP_CLI::confirm( sprintf( 'Transition experiment %s to %s?', $key, $state ), $assoc_args );
+		}
+
+		$transition = $this->execute(
+			'extrachill/transition-experiment-state',
+			array(
+				'experiment_key'     => $key,
+				'definition_version' => (int) $before['definition_version'],
+				'state'              => $state,
+			),
+			'Extra Chill Network'
+		);
+		$after      = $this->definition( $key );
+		$result     = compact( 'before', 'transition', 'after' );
+		$format     = $assoc_args['format'] ?? 'table';
+
+		if ( 'json' === $format ) {
+			WP_CLI::print_value( $result, array( 'format' => 'json' ) );
+			return;
+		}
+		if ( 'csv' === $format ) {
+			$this->display_csv( array( $result ) );
+			return;
+		}
+
+		WP_CLI::log( 'Before:' );
+		$this->display_definition( $before );
+		WP_CLI::log( 'Transition:' );
+		Utils\format_items( 'table', array( $transition ), array_keys( $transition ) );
+		WP_CLI::log( 'After:' );
+		$this->display_definition( $after );
+	}
+
+	/**
+	 * Report assignment, exposure, and outcomes for one experiment.
+	 *
+	 * ## OPTIONS
+	 *
+	 * <key>
+	 * : Stable experiment key.
+	 *
+	 * [--definition-version=<version>]
+	 * : Restrict stored events to one definition version. Omit to retain owner-provided mixed-version diagnostics.
+	 *
+	 * [--control-variant=<variant>]
+	 * : Control variant. Defaults to the current registered definition.
+	 *
+	 * [--variants=<variants>]
+	 * : Comma-separated variant IDs. Defaults to every current registered variant.
+	 *
+	 * [--outcome-event-types=<types>]
+	 * : Comma-separated canonical Analytics outcome event types.
+	 *
+	 * [--days=<days>]
+	 * : UTC lookback days. Accepted range: 1-90.
+	 * ---
+	 * default: 28
+	 * ---
+	 *
+	 * [--attribution-window-days=<days>]
+	 * : Outcome attribution window. Accepted range: 1-90.
+	 * ---
+	 * default: 28
+	 * ---
+	 *
+	 * [--session-gap-mins=<mins>]
+	 * : Inactivity gap separating sessions. Accepted range: 1-120.
+	 * ---
+	 * default: 30
+	 * ---
+	 *
+	 * [--max-events=<count>]
+	 * : Maximum retained rows. Accepted range: 100-100000.
+	 * ---
+	 * default: 50000
+	 * ---
+	 *
+	 * [--format=<format>]
+	 * : Output format. JSON and CSV preserve the complete Analytics owner envelope.
+	 * ---
+	 * default: table
+	 * options:
+	 *   - table
+	 *   - json
+	 *   - csv
+	 * ---
+	 *
+	 * ## EXAMPLES
+	 *
+	 *     wp extrachill experiments report geo-bridge-holdout
+	 *     wp extrachill experiments report geo-bridge-holdout --definition-version=1 --outcome-event-types=bridge_click --format=json
+	 *
+	 * @when after_wp_load
+	 */
+	public function report( $args, $assoc_args ) {
+		$definition = $this->definition( $args[0] ?? '' );
+		$input      = array(
+			'experiment_key'          => (string) $definition['key'],
+			'control_variant'         => (string) ( $assoc_args['control-variant'] ?? $definition['control_variant'] ),
+			'variants'                => isset( $assoc_args['variants'] ) ? $this->csv_values( $assoc_args['variants'] ) : array_keys( (array) $definition['variants'] ),
+			'outcome_event_types'     => isset( $assoc_args['outcome-event-types'] ) ? $this->csv_values( $assoc_args['outcome-event-types'] ) : array(),
+			'days'                    => (int) ( $assoc_args['days'] ?? 28 ),
+			'attribution_window_days' => (int) ( $assoc_args['attribution-window-days'] ?? 28 ),
+			'session_gap_mins'        => (int) ( $assoc_args['session-gap-mins'] ?? 30 ),
+			'max_events'              => (int) ( $assoc_args['max-events'] ?? 50000 ),
+		);
+		if ( isset( $assoc_args['definition-version'] ) ) {
+			$input['definition_version'] = (int) $assoc_args['definition-version'];
+		}
+
+		$result = $this->execute( 'extrachill/get-experiment-summary', $input, 'Extra Chill Analytics' );
+		$format = $assoc_args['format'] ?? 'table';
+		if ( 'json' === $format ) {
+			WP_CLI::print_value( $result, array( 'format' => 'json' ) );
+			return;
+		}
+		if ( 'csv' === $format ) {
+			$this->display_csv( array( $result ) );
+			return;
+		}
+
+		$this->display_report( $definition, $result );
+	}
+
+	/** Execute one owner ability and preserve its error message. */
+	private function execute( $name, array $input, $owner ) {
+		$ability = wp_get_ability( $name );
+		if ( ! $ability ) {
+			WP_CLI::error( sprintf( '%s ability not found. Is %s active and up to date?', $name, $owner ) );
+		}
+		$result = $ability->execute( $input );
+		if ( is_wp_error( $result ) ) {
+			WP_CLI::error( $result->get_error_message() );
+		}
+		return $result;
+	}
+
+	/** Find one complete definition envelope through Network's list ability. */
+	private function definition( $key ) {
+		foreach ( $this->execute( 'extrachill/list-experiments', array(), 'Extra Chill Network' ) as $definition ) {
+			if ( (string) ( $definition['key'] ?? '' ) === (string) $key ) {
+				return $definition;
+			}
+		}
+		WP_CLI::error( sprintf( 'Experiment %s is not registered.', (string) $key ) );
+	}
+
+	/** Render one Network definition without changing its values. */
+	private function display_definition( array $definition ) {
+		$state = $definition['state'] ?? null;
+		WP_CLI::log( sprintf( 'Experiment: %s', $this->human_value( $definition['key'] ?? null ) ) );
+		WP_CLI::log( sprintf( 'Definition version: %s', $this->human_value( $definition['definition_version'] ?? null ) ) );
+		WP_CLI::log( sprintf( 'Assignment policy: %s', $this->human_value( $definition['assignment_policy'] ?? null ) ) );
+		WP_CLI::log( sprintf( 'Code default state: %s', $this->human_value( $definition['default_state'] ?? null ) ) );
+		WP_CLI::log( sprintf( 'Effective/live state: %s', $this->human_value( $state ) ) );
+		WP_CLI::log( sprintf( 'Runtime status: %s', 'active' === $state ? 'assignment eligible when the consumer permits it' : 'no-op; normal consumer behavior remains unchanged' ) );
+		WP_CLI::log( sprintf( 'Default/control variant: %s / %s', $this->human_value( $definition['default_variant'] ?? null ), $this->human_value( $definition['control_variant'] ?? null ) ) );
+		WP_CLI::log( 'Variant weights: ' . $this->pairs( (array) ( $definition['variants'] ?? array() ) ) );
+		WP_CLI::log( 'Surfaces: ' . $this->values( (array) ( $definition['surfaces'] ?? array() ) ) );
+		WP_CLI::log( '' );
+	}
+
+	/** Render owner-produced report sections without calculating metrics. */
+	private function display_report( array $definition, array $result ) {
+		WP_CLI::log( sprintf( 'Experiment report: %s', $this->human_value( $result['experiment_key'] ?? $definition['key'] ?? null ) ) );
+		WP_CLI::log( sprintf( 'Definition version filter: %s', $this->human_value( $result['definition_version'] ?? null ) ) );
+		WP_CLI::log( sprintf( 'Control variant: %s; report state: %s', $this->human_value( $result['control_variant'] ?? null ), $this->human_value( $result['state'] ?? null ) ) );
+		WP_CLI::log( 'Assignment policy/weights: ' . $this->human_value( $definition['assignment_policy'] ?? null ) . '; ' . $this->pairs( (array) ( $definition['variants'] ?? array() ) ) );
+		WP_CLI::log( 'Registered surfaces: ' . $this->values( (array) ( $definition['surfaces'] ?? array() ) ) );
+
+		foreach ( (array) ( $result['variants'] ?? array() ) as $variant ) {
+			WP_CLI::log( '' );
+			WP_CLI::log( sprintf( 'Variant: %s', $this->human_value( $variant['variant'] ?? null ) ) );
+			$this->display_metric_group( 'Assignment (intent-to-treat)', (array) ( $variant['assignment'] ?? array() ) );
+			$this->display_metric_group( 'Exposure (descriptive, exposure-conditioned)', (array) ( $variant['exposure'] ?? array() ) );
+			foreach ( (array) ( $variant['outcomes'] ?? array() ) as $outcome => $metrics ) {
+				WP_CLI::log( sprintf( 'Outcome: %s; coverage: %s', $outcome, $this->human_value( $metrics['coverage_status'] ?? null ) ) );
+				$this->display_metric_group( '  After assignment (intent-to-treat; lift/confidence vs control)', $metrics['after_assignment'] ?? null );
+				$this->display_metric_group( '  After exposure (descriptive, exposure-conditioned)', $metrics['after_exposure'] ?? null );
+			}
+		}
+
+		WP_CLI::log( '' );
+		$this->display_metric_group( 'Version/surface/policy diagnostics', (array) ( $result['version_diagnostics'] ?? array() ) );
+		$this->display_metric_group( 'Coverage and insufficient-data diagnostics', (array) ( $result['coverage'] ?? array() ) );
+		WP_CLI::log( 'No winner is declared; null and unknown values remain unavailable rather than zero.' );
+	}
+
+	/** Render an owner metric group as key/value rows. */
+	private function display_metric_group( $label, $metrics ) {
+		WP_CLI::log( $label . ':' );
+		if ( null === $metrics ) {
+			WP_CLI::log( '  unavailable / insufficient data' );
+			return;
+		}
+		$rows = array();
+		foreach ( (array) $metrics as $key => $value ) {
+			$rows[] = array( 'metric' => $key, 'value' => $this->human_value( $value ) );
+		}
+		if ( empty( $rows ) ) {
+			WP_CLI::log( '  unavailable / insufficient data' );
+			return;
+		}
+		Utils\format_items( 'table', $rows, array( 'metric', 'value' ) );
+	}
+
+	/** Emit complete rows as CSV, JSON-encoding every nested value. */
+	private function display_csv( array $rows ) {
+		$fields = array();
+		foreach ( $rows as $row ) {
+			$fields = array_values( array_unique( array_merge( $fields, array_keys( (array) $row ) ) ) );
+		}
+		$flattened = array();
+		foreach ( $rows as $row ) {
+			$row = (array) $row;
+			foreach ( $row as $key => $value ) {
+				if ( is_array( $value ) || is_object( $value ) ) {
+					$row[ $key ] = wp_json_encode( $value );
+				}
+			}
+			$flattened[] = $row;
+		}
+		Utils\format_items( 'csv', $flattened, $fields );
+	}
+
+	/** Parse a comma-separated owner argument without changing its values. */
+	private function csv_values( $value ) {
+		return array_values( array_filter( array_map( 'trim', explode( ',', (string) $value ) ), 'strlen' ) );
+	}
+
+	/** Format arbitrary owner values for human output while preserving null. */
+	private function human_value( $value ) {
+		if ( null === $value ) {
+			return 'unavailable';
+		}
+		if ( is_bool( $value ) ) {
+			return $value ? 'true' : 'false';
+		}
+		if ( is_array( $value ) || is_object( $value ) ) {
+			return wp_json_encode( $value );
+		}
+		return (string) $value;
+	}
+
+	/** Format a keyed definition map for humans. */
+	private function pairs( array $values ) {
+		$pairs = array();
+		foreach ( $values as $key => $value ) {
+			$pairs[] = $key . '=' . $this->human_value( $value );
+		}
+		return empty( $pairs ) ? 'unavailable' : implode( ', ', $pairs );
+	}
+
+	/** Format a value list for humans. */
+	private function values( array $values ) {
+		return empty( $values ) ? 'unavailable' : implode( ', ', array_map( array( $this, 'human_value' ), $values ) );
+	}
+}

--- a/inc/Commands/Experiments/ExperimentsCommand.php
+++ b/inc/Commands/Experiments/ExperimentsCommand.php
@@ -37,6 +37,13 @@ class ExperimentsCommand {
 	 *
 	 *     wp extrachill experiments list
 	 *     wp extrachill experiments list --format=json
+	 *     wp --allow-root --path=/var/www/extrachill.com extrachill experiments list
+	 *
+	 * ## NOTES
+	 *
+	 * Network permits trusted local WP-CLI execution of its private experiment
+	 * admin Abilities. Use the standard local command above without `--user`;
+	 * web and REST callers still require Network's administrative capability.
 	 *
 	 * @subcommand list
 	 * @when after_wp_load
@@ -146,6 +153,7 @@ class ExperimentsCommand {
 		$key    = (string) ( $args[0] ?? '' );
 		$state  = (string) ( $args[1] ?? '' );
 		$before = $this->definition( $key );
+		$this->require_registered( $before, 'transition state' );
 
 		if ( in_array( $state, array( 'active', 'completed' ), true ) ) {
 			WP_CLI::confirm( sprintf( 'Transition experiment %s to %s?', $key, $state ), $assoc_args );
@@ -202,28 +210,16 @@ class ExperimentsCommand {
 	 * : Comma-separated canonical Analytics outcome event types.
 	 *
 	 * [--days=<days>]
-	 * : UTC lookback days. Accepted range: 1-90.
-	 * ---
-	 * default: 28
-	 * ---
+	 * : UTC lookback days. Accepted range: 1-90. Omit to use the Analytics owner default.
 	 *
 	 * [--attribution-window-days=<days>]
-	 * : Outcome attribution window. Accepted range: 1-90.
-	 * ---
-	 * default: 28
-	 * ---
+	 * : Outcome attribution window. Accepted range: 1-90. Omit to use the Analytics owner default.
 	 *
 	 * [--session-gap-mins=<mins>]
-	 * : Inactivity gap separating sessions. Accepted range: 1-120.
-	 * ---
-	 * default: 30
-	 * ---
+	 * : Inactivity gap separating sessions. Accepted range: 1-120. Omit to use the Analytics owner default.
 	 *
 	 * [--max-events=<count>]
-	 * : Maximum retained rows. Accepted range: 100-100000.
-	 * ---
-	 * default: 50000
-	 * ---
+	 * : Maximum retained rows. Accepted range: 100-100000. Omit to use the Analytics owner default.
 	 *
 	 * [--format=<format>]
 	 * : Output format. JSON and CSV preserve the complete Analytics owner envelope.
@@ -244,18 +240,27 @@ class ExperimentsCommand {
 	 */
 	public function report( $args, $assoc_args ) {
 		$definition = $this->definition( $args[0] ?? '' );
+		$this->require_registered( $definition, 'report' );
 		$input      = array(
-			'experiment_key'          => (string) $definition['key'],
-			'control_variant'         => (string) ( $assoc_args['control-variant'] ?? $definition['control_variant'] ),
-			'variants'                => isset( $assoc_args['variants'] ) ? $this->csv_values( $assoc_args['variants'] ) : array_keys( (array) $definition['variants'] ),
-			'outcome_event_types'     => isset( $assoc_args['outcome-event-types'] ) ? $this->csv_values( $assoc_args['outcome-event-types'] ) : array(),
-			'days'                    => (int) ( $assoc_args['days'] ?? 28 ),
-			'attribution_window_days' => (int) ( $assoc_args['attribution-window-days'] ?? 28 ),
-			'session_gap_mins'        => (int) ( $assoc_args['session-gap-mins'] ?? 30 ),
-			'max_events'              => (int) ( $assoc_args['max-events'] ?? 50000 ),
+			'experiment_key'  => (string) $definition['key'],
+			'control_variant' => (string) ( $assoc_args['control-variant'] ?? $definition['control_variant'] ),
+			'variants'        => isset( $assoc_args['variants'] ) ? $this->csv_values( $assoc_args['variants'] ) : array_keys( (array) $definition['variants'] ),
 		);
-		if ( isset( $assoc_args['definition-version'] ) ) {
-			$input['definition_version'] = (int) $assoc_args['definition-version'];
+		$optional = array(
+			'definition-version'      => 'definition_version',
+			'outcome-event-types'     => 'outcome_event_types',
+			'days'                    => 'days',
+			'attribution-window-days' => 'attribution_window_days',
+			'session-gap-mins'        => 'session_gap_mins',
+			'max-events'              => 'max_events',
+		);
+		foreach ( $optional as $cli_key => $ability_key ) {
+			if ( ! isset( $assoc_args[ $cli_key ] ) ) {
+				continue;
+			}
+			$input[ $ability_key ] = 'outcome-event-types' === $cli_key
+				? $this->csv_values( $assoc_args[ $cli_key ] )
+				: (int) $assoc_args[ $cli_key ];
 		}
 
 		$result = $this->execute( 'extrachill/get-experiment-summary', $input, 'Extra Chill Analytics' );
@@ -295,15 +300,31 @@ class ExperimentsCommand {
 		WP_CLI::error( sprintf( 'Experiment %s is not registered.', (string) $key ) );
 	}
 
+	/** Reject owner-reported orphan rows before mutation or analytics calls. */
+	private function require_registered( array $definition, $operation ) {
+		if ( ! empty( $definition['registered'] ) && empty( $definition['orphaned'] ) ) {
+			return;
+		}
+		WP_CLI::error(
+			sprintf(
+				'Experiment %s is an orphaned lifecycle record without a registered code definition; cannot %s.',
+				(string) ( $definition['key'] ?? '' ),
+				$operation
+			)
+		);
+	}
+
 	/** Render one Network definition without changing its values. */
 	private function display_definition( array $definition ) {
-		$state = $definition['state'] ?? null;
+		$state      = $definition['state'] ?? null;
+		$registered = ! empty( $definition['registered'] ) && empty( $definition['orphaned'] );
 		WP_CLI::log( sprintf( 'Experiment: %s', $this->human_value( $definition['key'] ?? null ) ) );
+		WP_CLI::log( sprintf( 'Registry status: %s', $registered ? 'registered code definition' : 'orphaned lifecycle record (not registered; inspection only)' ) );
 		WP_CLI::log( sprintf( 'Definition version: %s', $this->human_value( $definition['definition_version'] ?? null ) ) );
 		WP_CLI::log( sprintf( 'Assignment policy: %s', $this->human_value( $definition['assignment_policy'] ?? null ) ) );
 		WP_CLI::log( sprintf( 'Code default state: %s', $this->human_value( $definition['default_state'] ?? null ) ) );
 		WP_CLI::log( sprintf( 'Effective/live state: %s', $this->human_value( $state ) ) );
-		WP_CLI::log( sprintf( 'Runtime status: %s', 'active' === $state ? 'assignment eligible when the consumer permits it' : 'no-op; normal consumer behavior remains unchanged' ) );
+		WP_CLI::log( sprintf( 'Runtime status: %s', $registered && 'active' === $state ? 'assignment eligible when the consumer permits it' : 'no-op; normal consumer behavior remains unchanged' ) );
 		WP_CLI::log( sprintf( 'Default/control variant: %s / %s', $this->human_value( $definition['default_variant'] ?? null ), $this->human_value( $definition['control_variant'] ?? null ) ) );
 		WP_CLI::log( 'Variant weights: ' . $this->pairs( (array) ( $definition['variants'] ?? array() ) ) );
 		WP_CLI::log( 'Surfaces: ' . $this->values( (array) ( $definition['surfaces'] ?? array() ) ) );
@@ -333,6 +354,9 @@ class ExperimentsCommand {
 		WP_CLI::log( '' );
 		$this->display_metric_group( 'Version/surface/policy diagnostics', (array) ( $result['version_diagnostics'] ?? array() ) );
 		$this->display_metric_group( 'Coverage and insufficient-data diagnostics', (array) ( $result['coverage'] ?? array() ) );
+		$this->display_metric_group( 'Analytics owner contract and interpretation', (array) ( $result['contract'] ?? array() ) );
+		$this->display_metric_group( 'Analytics owner window', (array) ( $result['window'] ?? array() ) );
+		$this->display_metric_group( 'Analytics owner query and bounds', (array) ( $result['query'] ?? array() ) );
 		WP_CLI::log( 'No winner is declared; null and unknown values remain unavailable rather than zero.' );
 	}
 

--- a/tests/ExperimentsCommandTest.php
+++ b/tests/ExperimentsCommandTest.php
@@ -62,6 +62,8 @@ namespace {
 	$experiments_command_test_definitions = array(
 		array(
 			'key'                  => 'copy-test',
+			'registered'           => true,
+			'orphaned'             => false,
 			'definition_version'   => 3,
 			'assignment_policy'    => 'weighted_random',
 			'default_state'        => 'inactive',
@@ -74,6 +76,8 @@ namespace {
 		),
 		array(
 			'key'                  => 'version-test',
+			'registered'           => true,
+			'orphaned'             => false,
 			'definition_version'   => 2,
 			'assignment_policy'    => 'weighted_random',
 			'default_state'        => 'active',
@@ -82,6 +86,19 @@ namespace {
 			'control_variant'      => 'control',
 			'variants'             => array( 'control' => 50, 'treatment' => 50 ),
 			'surfaces'             => array( 'link-page' ),
+		),
+		array(
+			'key'                  => 'removed-test',
+			'registered'           => false,
+			'orphaned'             => true,
+			'definition_version'   => 1,
+			'assignment_policy'    => '',
+			'default_state'        => 'inactive',
+			'state'                => 'paused',
+			'default_variant'      => '',
+			'control_variant'      => '',
+			'variants'             => array(),
+			'surfaces'             => array(),
 		),
 	);
 
@@ -196,6 +213,14 @@ namespace {
 		),
 		'version_diagnostics' => array( 'observed_event_rows_by_version' => array( 1 => 8, 3 => 18 ), 'mixed_versions_observed' => true, 'requested_version' => null, 'surfaces' => array( 'hero', 'footer' ), 'assignment_policies' => array( 'weighted_random' ) ),
 		'coverage'            => array( 'loaded_rows' => 26, 'truncated' => false, 'no_data_semantics' => 'Null is not zero.' ),
+		'contract'            => array(
+			'assignment' => 'The first valid assignment fixes a person variant and version.',
+			'exposure'   => 'Exposure is never inferred. Exposure-conditioned outcomes are descriptive and may be selection-biased.',
+			'outcomes'   => 'Each requested canonical outcome counts once per person and lens.',
+			'statistics' => 'Nulls carry explicit status. No winner is selected.',
+		),
+		'window'              => array( 'since' => '2026-06-20 00:00:00', 'as_of' => '2026-07-18 00:00:00', 'days' => 28, 'attribution_window_days' => 28, 'session_gap_mins' => 30 ),
+		'query'               => array( 'event_types' => array( 'experiment_assignment', 'experiment_exposure' ), 'page_size' => 500, 'max_events' => 50000, 'bounded_state' => 'Variants and outcomes are bounded by the owner.' ),
 		'future_report'       => array( 'sample_size' => 14, 'ratio' => 0.625, 'available' => false ),
 	);
 	$report_ability = new ExperimentsCommandTestAbility(
@@ -224,6 +249,9 @@ namespace {
 	experiments_command_test_reset_output();
 	$command->get( array( 'copy-test' ), array( 'format' => 'json' ) );
 	experiments_command_test_assert_same( $experiments_command_test_definitions[0], WP_CLI::$printed[0]['value'], 'Get JSON must preserve one complete definition.' );
+	experiments_command_test_reset_output();
+	$command->get( array( 'removed-test' ), array( 'format' => 'json' ) );
+	experiments_command_test_assert_same( $experiments_command_test_definitions[2], WP_CLI::$printed[0]['value'], 'Get JSON must permit inspection of a complete orphan owner row.' );
 
 	// Inactive human output explicitly reports effective no-op behavior.
 	experiments_command_test_reset_output();
@@ -234,6 +262,31 @@ namespace {
 	experiments_command_test_assert_contains( 'no-op; normal consumer behavior remains unchanged', $human, 'Inactive definitions must be labeled no-op.' );
 	experiments_command_test_assert_contains( 'control=40, challenger-a=35, challenger-b=25', $human, 'Human definition output must separate weights.' );
 	experiments_command_test_assert_contains( 'Surfaces: hero, footer', $human, 'Human definition output must separate surfaces.' );
+	experiments_command_test_reset_output();
+	$command->get( array( 'removed-test' ), array() );
+	$orphan_human = implode( "\n", WP_CLI::$messages );
+	experiments_command_test_assert_contains( 'orphaned lifecycle record (not registered; inspection only)', $orphan_human, 'Human get must label owner-reported orphan rows explicitly.' );
+	experiments_command_test_assert_contains( 'no-op; normal consumer behavior remains unchanged', $orphan_human, 'Orphan lifecycle rows must be labeled no-op even when stored state is active-like.' );
+
+	// Orphan state/report fail before confirmation or downstream Ability execution.
+	$transition_calls_before_orphan = count( $transition_ability->inputs );
+	$report_calls_before_orphan     = count( $report_ability->inputs );
+	experiments_command_test_reset_output();
+	try {
+		$command->state( array( 'removed-test', 'active' ), array() );
+		throw new \RuntimeException( 'Orphan state did not terminate.' );
+	} catch ( ExperimentsCommandTestError $error ) {
+		experiments_command_test_assert_contains( 'orphaned lifecycle record without a registered code definition', $error->getMessage(), 'Orphan state must explain the owner state honestly.' );
+	}
+	experiments_command_test_assert_same( 0, count( WP_CLI::$confirmations ), 'Orphan state must fail before confirmation.' );
+	experiments_command_test_assert_same( $transition_calls_before_orphan, count( $transition_ability->inputs ), 'Orphan state must fail before transition Ability execution.' );
+	try {
+		$command->report( array( 'removed-test' ), array() );
+		throw new \RuntimeException( 'Orphan report did not terminate.' );
+	} catch ( ExperimentsCommandTestError $error ) {
+		experiments_command_test_assert_contains( 'orphaned lifecycle record without a registered code definition', $error->getMessage(), 'Orphan report must explain the owner state honestly.' );
+	}
+	experiments_command_test_assert_same( $report_calls_before_orphan, count( $report_ability->inputs ), 'Orphan report must fail before Analytics Ability execution.' );
 
 	// Active and completed transitions confirm, map exact owner arguments, and retain before/after envelopes.
 	experiments_command_test_reset_output();
@@ -274,12 +327,12 @@ namespace {
 			'experiment_key'          => 'copy-test',
 			'control_variant'         => 'control',
 			'variants'                => array( 'control', 'challenger-a', 'challenger-b' ),
+			'definition_version'      => 2,
 			'outcome_event_types'     => array( 'newsletter_signup', 'bridge_click' ),
 			'days'                    => 90,
 			'attribution_window_days' => 45,
 			'session_gap_mins'        => 120,
 			'max_events'              => 100000,
-			'definition_version'      => 2,
 		),
 		$report_ability->inputs[0],
 		'Report must map every bounded Analytics field exactly.'
@@ -293,17 +346,12 @@ namespace {
 	$command->report( array( 'copy-test' ), array( 'format' => 'csv' ) );
 	experiments_command_test_assert_same(
 		array(
-			'experiment_key'          => 'copy-test',
-			'control_variant'         => 'control',
-			'variants'                => array( 'control', 'challenger-a', 'challenger-b' ),
-			'outcome_event_types'     => array(),
-			'days'                    => 28,
-			'attribution_window_days' => 28,
-			'session_gap_mins'        => 30,
-			'max_events'              => 50000,
+			'experiment_key'  => 'copy-test',
+			'control_variant' => 'control',
+			'variants'        => array( 'control', 'challenger-a', 'challenger-b' ),
 		),
 		$report_ability->inputs[1],
-		'Report defaults must derive only required definition dimensions and exact owner defaults.'
+		'Report must omit every unspecified optional field so Analytics owns defaults.'
 	);
 	$report_csv = $experiments_command_test_formats[0];
 	experiments_command_test_assert_same( array_keys( $report_result ), $report_csv['fields'], 'Report CSV must retain every owner field.' );
@@ -320,7 +368,30 @@ namespace {
 	experiments_command_test_assert_contains( 'unavailable / insufficient data', $human, 'Human report must preserve insufficient-data states.' );
 	experiments_command_test_assert_contains( 'Version/surface/policy diagnostics', $human, 'Human report must show mixed-version and surface diagnostics.' );
 	experiments_command_test_assert_contains( 'Coverage and insufficient-data diagnostics', $human, 'Human report must separate coverage.' );
+	experiments_command_test_assert_contains( 'Analytics owner contract and interpretation', $human, 'Human report must label the Analytics owner contract.' );
+	experiments_command_test_assert_contains( 'Analytics owner window', $human, 'Human report must render the owner window.' );
+	experiments_command_test_assert_contains( 'Analytics owner query and bounds', $human, 'Human report must render owner query bounds.' );
 	experiments_command_test_assert_contains( 'No winner is declared', $human, 'Human report must expressly avoid winner selection.' );
+	$contract_table = null;
+	$window_table   = null;
+	$query_table    = null;
+	foreach ( $experiments_command_test_formats as $table ) {
+		foreach ( $table['items'] as $row ) {
+			if ( 'exposure' === ( $row['metric'] ?? '' ) ) {
+				$contract_table = $table;
+			}
+			if ( 'since' === ( $row['metric'] ?? '' ) ) {
+				$window_table = $table;
+			}
+			if ( 'bounded_state' === ( $row['metric'] ?? '' ) ) {
+				$query_table = $table;
+			}
+		}
+	}
+	experiments_command_test_assert_true( null !== $contract_table, 'Human output must table the Analytics owner contract.' );
+	experiments_command_test_assert_contains( 'selection-biased', wp_json_encode( $contract_table['items'] ), 'Human contract output must retain the exposure-selection-bias interpretation.' );
+	experiments_command_test_assert_true( null !== $window_table, 'Human output must table Analytics owner window fields.' );
+	experiments_command_test_assert_true( null !== $query_table, 'Human output must table Analytics owner query/bounds fields.' );
 
 	// Owner permission and transition errors pass through without replacement.
 	$experiments_command_test_abilities['extrachill/list-experiments'] = new ExperimentsCommandTestAbility(

--- a/tests/ExperimentsCommandTest.php
+++ b/tests/ExperimentsCommandTest.php
@@ -1,0 +1,354 @@
+<?php
+/**
+ * Focused contract and presentation tests for platform experiment adapters.
+ */
+
+namespace {
+	define( 'ABSPATH', __DIR__ . '/' );
+
+	class ExperimentsCommandTestError extends \RuntimeException {}
+
+	class WP_CLI {
+		public static $messages      = array();
+		public static $printed       = array();
+		public static $confirmations = array();
+
+		public static function error( $message ) {
+			throw new ExperimentsCommandTestError( $message );
+		}
+
+		public static function log( $message ) {
+			self::$messages[] = $message;
+		}
+
+		public static function print_value( $value, $args ) {
+			self::$printed[] = compact( 'value', 'args' );
+		}
+
+		public static function confirm( $message, $assoc_args = array() ) {
+			self::$confirmations[] = compact( 'message', 'assoc_args' );
+		}
+	}
+
+	class ExperimentsCommandTestErrorValue {
+		public $code;
+		private $message;
+
+		public function __construct( $code, $message ) {
+			$this->code    = $code;
+			$this->message = $message;
+		}
+
+		public function get_error_message() {
+			return $this->message;
+		}
+	}
+
+	class ExperimentsCommandTestAbility {
+		public $inputs = array();
+		private $callback;
+
+		public function __construct( $callback ) {
+			$this->callback = $callback;
+		}
+
+		public function execute( $input ) {
+			$this->inputs[] = $input;
+			return call_user_func( $this->callback, $input );
+		}
+	}
+
+	$experiments_command_test_abilities   = array();
+	$experiments_command_test_definitions = array(
+		array(
+			'key'                  => 'copy-test',
+			'definition_version'   => 3,
+			'assignment_policy'    => 'weighted_random',
+			'default_state'        => 'inactive',
+			'state'                => 'inactive',
+			'default_variant'      => 'control',
+			'control_variant'      => 'control',
+			'variants'             => array( 'control' => 40, 'challenger-a' => 35, 'challenger-b' => 25 ),
+			'surfaces'             => array( 'hero', 'footer' ),
+			'future_definition'    => array( 'typed' => true, 'threshold' => 0.75 ),
+		),
+		array(
+			'key'                  => 'version-test',
+			'definition_version'   => 2,
+			'assignment_policy'    => 'weighted_random',
+			'default_state'        => 'active',
+			'state'                => 'active',
+			'default_variant'      => 'control',
+			'control_variant'      => 'control',
+			'variants'             => array( 'control' => 50, 'treatment' => 50 ),
+			'surfaces'             => array( 'link-page' ),
+		),
+	);
+
+	function wp_get_ability( $name ) {
+		global $experiments_command_test_abilities;
+		return $experiments_command_test_abilities[ $name ] ?? null;
+	}
+
+	function is_wp_error( $value ) {
+		return $value instanceof ExperimentsCommandTestErrorValue;
+	}
+
+	function wp_json_encode( $value ) {
+		return json_encode( $value );
+	}
+
+	function experiments_command_test_assert_same( $expected, $actual, $message ) {
+		if ( $expected !== $actual ) {
+			throw new \RuntimeException( $message . '\nExpected: ' . var_export( $expected, true ) . '\nActual: ' . var_export( $actual, true ) );
+		}
+	}
+
+	function experiments_command_test_assert_true( $value, $message ) {
+		if ( ! $value ) {
+			throw new \RuntimeException( $message );
+		}
+
+	}
+
+	function experiments_command_test_assert_contains( $needle, $haystack, $message ) {
+		if ( false === strpos( $haystack, $needle ) ) {
+			throw new \RuntimeException( $message . '\nMissing: ' . $needle );
+		}
+	}
+
+	function experiments_command_test_reset_output() {
+		WP_CLI::$messages      = array();
+		WP_CLI::$printed       = array();
+		WP_CLI::$confirmations = array();
+		$GLOBALS['experiments_command_test_formats'] = array();
+	}
+}
+
+namespace WP_CLI\Utils {
+	$experiments_command_test_formats = array();
+
+	function format_items( $format, $items, $fields ) {
+		global $experiments_command_test_formats;
+		$experiments_command_test_formats[] = compact( 'format', 'items', 'fields' );
+	}
+}
+
+namespace {
+	require_once dirname( __DIR__ ) . '/inc/Commands/Experiments/ExperimentsCommand.php';
+
+	use ExtraChill\CLI\Commands\Experiments\ExperimentsCommand;
+
+	global $experiments_command_test_abilities, $experiments_command_test_definitions, $experiments_command_test_formats;
+
+	$list_ability = new ExperimentsCommandTestAbility(
+		static function () use ( &$experiments_command_test_definitions ) {
+			return $experiments_command_test_definitions;
+		}
+	);
+	$transition_ability = new ExperimentsCommandTestAbility(
+		static function ( $input ) use ( &$experiments_command_test_definitions ) {
+			foreach ( $experiments_command_test_definitions as &$definition ) {
+				if ( $definition['key'] === $input['experiment_key'] ) {
+					$previous           = $definition['state'];
+					$definition['state'] = $input['state'];
+					return array(
+						'experiment_key'     => $input['experiment_key'],
+						'definition_version' => $input['definition_version'],
+						'previous_state'     => $previous,
+						'state'              => $input['state'],
+					);
+				}
+			}
+			return new ExperimentsCommandTestErrorValue( 'experiment_not_registered', 'Experiment is not registered.' );
+		}
+	);
+	$report_result = array(
+		'experiment_key'     => 'copy-test',
+		'definition_version' => null,
+		'control_variant'    => 'control',
+		'state'              => 'measured',
+		'variants'           => array(
+			array(
+				'variant'    => 'control',
+				'assignment' => array( 'people' => 10, 'stored_events' => 11, 'coverage_status' => 'measured' ),
+				'exposure'   => array( 'people' => 8, 'stored_events' => 8, 'rate' => 0.8, 'rate_status' => 'measured', 'rate_ci_95' => array( 'lower' => 0.49, 'upper' => 0.94 ), 'coverage_status' => 'measured', 'analysis_lens' => 'descriptive' ),
+				'outcomes'   => array(
+					'newsletter_signup' => array(
+						'coverage_status'  => 'measured',
+						'after_assignment' => array( 'people' => 2, 'rate' => 0.2, 'rate_status' => 'measured', 'rate_ci_95' => array( 'lower' => 0.06, 'upper' => 0.51 ), 'lift_vs_control' => array( 'absolute' => 0.0, 'relative' => 0.0, 'absolute_ci_95' => null, 'relative_ci_95' => null, 'status' => 'control_reference' ) ),
+						'after_exposure'   => array( 'people' => 2, 'rate' => 0.25, 'rate_status' => 'measured', 'analysis_lens' => 'descriptive_exposure_conditioned' ),
+					),
+				),
+			),
+			array(
+				'variant'    => 'challenger-a',
+				'assignment' => array( 'people' => 0, 'stored_events' => 0, 'coverage_status' => 'measured' ),
+				'exposure'   => array( 'people' => 0, 'stored_events' => 0, 'rate' => null, 'rate_status' => 'zero_denominator', 'rate_ci_95' => null, 'coverage_status' => 'measured', 'analysis_lens' => 'descriptive' ),
+				'outcomes'   => array( 'newsletter_signup' => array( 'coverage_status' => 'measured', 'after_assignment' => array( 'people' => 0, 'rate' => null, 'rate_status' => 'zero_denominator', 'rate_ci_95' => null, 'lift_vs_control' => array( 'absolute' => null, 'relative' => null, 'status' => 'zero_denominator' ) ), 'after_exposure' => null ) ),
+			),
+			array(
+				'variant'    => 'challenger-b',
+				'assignment' => array( 'people' => 4, 'stored_events' => 4, 'coverage_status' => 'measured' ),
+				'exposure'   => array( 'people' => 3, 'stored_events' => 3, 'rate' => 0.75, 'rate_status' => 'measured', 'coverage_status' => 'measured', 'analysis_lens' => 'descriptive' ),
+				'outcomes'   => array(),
+			),
+		),
+		'version_diagnostics' => array( 'observed_event_rows_by_version' => array( 1 => 8, 3 => 18 ), 'mixed_versions_observed' => true, 'requested_version' => null, 'surfaces' => array( 'hero', 'footer' ), 'assignment_policies' => array( 'weighted_random' ) ),
+		'coverage'            => array( 'loaded_rows' => 26, 'truncated' => false, 'no_data_semantics' => 'Null is not zero.' ),
+		'future_report'       => array( 'sample_size' => 14, 'ratio' => 0.625, 'available' => false ),
+	);
+	$report_ability = new ExperimentsCommandTestAbility(
+		static function () use ( &$report_result ) {
+			return $report_result;
+		}
+	);
+	$experiments_command_test_abilities = array(
+		'extrachill/list-experiments'             => $list_ability,
+		'extrachill/transition-experiment-state' => $transition_ability,
+		'extrachill/get-experiment-summary'       => $report_ability,
+	);
+	$command = new ExperimentsCommand();
+
+	// List/get machine output retains complete typed definitions and future fields.
+	$command->list_( array(), array( 'format' => 'json' ) );
+	experiments_command_test_assert_same( $experiments_command_test_definitions, WP_CLI::$printed[0]['value'], 'List JSON must preserve every owner definition.' );
+	experiments_command_test_assert_same( 3, WP_CLI::$printed[0]['value'][0]['definition_version'], 'List JSON versions must remain integers.' );
+	experiments_command_test_assert_same( true, WP_CLI::$printed[0]['value'][0]['future_definition']['typed'], 'List JSON future booleans must remain typed.' );
+	experiments_command_test_reset_output();
+	$command->list_( array(), array( 'format' => 'csv' ) );
+	$csv = $experiments_command_test_formats[0];
+	experiments_command_test_assert_true( in_array( 'future_definition', $csv['fields'], true ), 'List CSV must union every future owner field.' );
+	experiments_command_test_assert_same( $experiments_command_test_definitions[0]['variants'], json_decode( $csv['items'][0]['variants'], true ), 'List CSV must JSON-encode variant weights.' );
+	experiments_command_test_assert_same( 0.75, json_decode( $csv['items'][0]['future_definition'], true )['threshold'], 'List CSV must retain nested numeric types.' );
+	experiments_command_test_reset_output();
+	$command->get( array( 'copy-test' ), array( 'format' => 'json' ) );
+	experiments_command_test_assert_same( $experiments_command_test_definitions[0], WP_CLI::$printed[0]['value'], 'Get JSON must preserve one complete definition.' );
+
+	// Inactive human output explicitly reports effective no-op behavior.
+	experiments_command_test_reset_output();
+	$command->get( array( 'copy-test' ), array() );
+	$human = implode( "\n", WP_CLI::$messages );
+	experiments_command_test_assert_contains( 'Code default state: inactive', $human, 'Human definition output must separate the code default.' );
+	experiments_command_test_assert_contains( 'Effective/live state: inactive', $human, 'Human definition output must show effective/live state.' );
+	experiments_command_test_assert_contains( 'no-op; normal consumer behavior remains unchanged', $human, 'Inactive definitions must be labeled no-op.' );
+	experiments_command_test_assert_contains( 'control=40, challenger-a=35, challenger-b=25', $human, 'Human definition output must separate weights.' );
+	experiments_command_test_assert_contains( 'Surfaces: hero, footer', $human, 'Human definition output must separate surfaces.' );
+
+	// Active and completed transitions confirm, map exact owner arguments, and retain before/after envelopes.
+	experiments_command_test_reset_output();
+	$command->state( array( 'copy-test', 'active' ), array( 'yes' => true, 'format' => 'json' ) );
+	experiments_command_test_assert_same( 1, count( WP_CLI::$confirmations ), 'Activation must use interactive confirmation.' );
+	experiments_command_test_assert_same( true, WP_CLI::$confirmations[0]['assoc_args']['yes'], 'Confirmation must support WP-CLI safe --yes bypass.' );
+	experiments_command_test_assert_same( array( 'experiment_key' => 'copy-test', 'definition_version' => 3, 'state' => 'active' ), $transition_ability->inputs[0], 'State must invoke Network transition with exact fields.' );
+	experiments_command_test_assert_same( 'inactive', WP_CLI::$printed[0]['value']['before']['state'], 'State JSON must retain the complete before owner envelope.' );
+	experiments_command_test_assert_same( 'active', WP_CLI::$printed[0]['value']['after']['state'], 'State JSON must retain the complete after owner envelope.' );
+	experiments_command_test_assert_same( $experiments_command_test_definitions[0]['future_definition'], WP_CLI::$printed[0]['value']['after']['future_definition'], 'State JSON must retain future owner fields.' );
+
+	$experiments_command_test_definitions[0]['state'] = 'paused';
+	experiments_command_test_reset_output();
+	$command->state( array( 'copy-test', 'completed' ), array( 'format' => 'csv' ) );
+	experiments_command_test_assert_same( 1, count( WP_CLI::$confirmations ), 'Completion must require confirmation.' );
+	experiments_command_test_assert_same( 'csv', $experiments_command_test_formats[0]['format'], 'State must support complete CSV output.' );
+	experiments_command_test_assert_same( 'paused', json_decode( $experiments_command_test_formats[0]['items'][0]['before'], true )['state'], 'State CSV must retain nested before values.' );
+	experiments_command_test_assert_same( 'completed', json_decode( $experiments_command_test_formats[0]['items'][0]['after'], true )['state'], 'State CSV must retain nested after values.' );
+
+	// Report maps every bounded Analytics input exactly and preserves machine types/future fields.
+	experiments_command_test_reset_output();
+	$command->report(
+		array( 'copy-test' ),
+		array(
+			'definition-version'      => '2',
+			'control-variant'         => 'control',
+			'variants'                => 'control,challenger-a,challenger-b',
+			'outcome-event-types'     => 'newsletter_signup,bridge_click',
+			'days'                    => '90',
+			'attribution-window-days' => '45',
+			'session-gap-mins'        => '120',
+			'max-events'              => '100000',
+			'format'                  => 'json',
+		)
+	);
+	experiments_command_test_assert_same(
+		array(
+			'experiment_key'          => 'copy-test',
+			'control_variant'         => 'control',
+			'variants'                => array( 'control', 'challenger-a', 'challenger-b' ),
+			'outcome_event_types'     => array( 'newsletter_signup', 'bridge_click' ),
+			'days'                    => 90,
+			'attribution_window_days' => 45,
+			'session_gap_mins'        => 120,
+			'max_events'              => 100000,
+			'definition_version'      => 2,
+		),
+		$report_ability->inputs[0],
+		'Report must map every bounded Analytics field exactly.'
+	);
+	experiments_command_test_assert_same( $report_result, WP_CLI::$printed[0]['value'], 'Report JSON must preserve the complete Analytics envelope.' );
+	experiments_command_test_assert_same( null, WP_CLI::$printed[0]['value']['variants'][1]['exposure']['rate'], 'Report JSON must preserve null denominators.' );
+	experiments_command_test_assert_same( 0.625, WP_CLI::$printed[0]['value']['future_report']['ratio'], 'Report JSON must retain future numeric fields.' );
+	experiments_command_test_assert_same( false, WP_CLI::$printed[0]['value']['future_report']['available'], 'Report JSON must retain future boolean fields.' );
+
+	experiments_command_test_reset_output();
+	$command->report( array( 'copy-test' ), array( 'format' => 'csv' ) );
+	experiments_command_test_assert_same(
+		array(
+			'experiment_key'          => 'copy-test',
+			'control_variant'         => 'control',
+			'variants'                => array( 'control', 'challenger-a', 'challenger-b' ),
+			'outcome_event_types'     => array(),
+			'days'                    => 28,
+			'attribution_window_days' => 28,
+			'session_gap_mins'        => 30,
+			'max_events'              => 50000,
+		),
+		$report_ability->inputs[1],
+		'Report defaults must derive only required definition dimensions and exact owner defaults.'
+	);
+	$report_csv = $experiments_command_test_formats[0];
+	experiments_command_test_assert_same( array_keys( $report_result ), $report_csv['fields'], 'Report CSV must retain every owner field.' );
+	experiments_command_test_assert_same( null, json_decode( $report_csv['items'][0]['variants'], true )[1]['exposure']['rate'], 'Report CSV nested null must remain null.' );
+	experiments_command_test_assert_same( $report_result['future_report'], json_decode( $report_csv['items'][0]['future_report'], true ), 'Report CSV must retain future nested fields.' );
+
+	// Human report separates statistical lenses, diagnostics, and never declares a winner.
+	experiments_command_test_reset_output();
+	$command->report( array( 'copy-test' ), array() );
+	$human = implode( "\n", WP_CLI::$messages );
+	experiments_command_test_assert_contains( 'Assignment (intent-to-treat)', $human, 'Human report must label assignment ITT.' );
+	experiments_command_test_assert_contains( 'Exposure (descriptive, exposure-conditioned)', $human, 'Human report must label exposure-conditioned metrics descriptive.' );
+	experiments_command_test_assert_contains( 'lift/confidence vs control', $human, 'Human report must separate lift and confidence.' );
+	experiments_command_test_assert_contains( 'unavailable / insufficient data', $human, 'Human report must preserve insufficient-data states.' );
+	experiments_command_test_assert_contains( 'Version/surface/policy diagnostics', $human, 'Human report must show mixed-version and surface diagnostics.' );
+	experiments_command_test_assert_contains( 'Coverage and insufficient-data diagnostics', $human, 'Human report must separate coverage.' );
+	experiments_command_test_assert_contains( 'No winner is declared', $human, 'Human report must expressly avoid winner selection.' );
+
+	// Owner permission and transition errors pass through without replacement.
+	$experiments_command_test_abilities['extrachill/list-experiments'] = new ExperimentsCommandTestAbility(
+		static function () {
+			return new ExperimentsCommandTestErrorValue( 'rest_forbidden', 'Sorry, you are not allowed to manage experiment lifecycle.' );
+		}
+	);
+	try {
+		$command->list_( array(), array() );
+		throw new \RuntimeException( 'Permission error did not terminate list.' );
+	} catch ( ExperimentsCommandTestError $error ) {
+		experiments_command_test_assert_same( 'Sorry, you are not allowed to manage experiment lifecycle.', $error->getMessage(), 'List permission errors must propagate unchanged.' );
+	}
+	$experiments_command_test_abilities['extrachill/list-experiments'] = $list_ability;
+	$experiments_command_test_abilities['extrachill/transition-experiment-state'] = new ExperimentsCommandTestAbility(
+		static function () {
+			return new ExperimentsCommandTestErrorValue( 'invalid_experiment_state_transition', 'Experiment lifecycle transition is invalid.' );
+		}
+	);
+	try {
+		$command->state( array( 'copy-test', 'active' ), array( 'yes' => true ) );
+		throw new \RuntimeException( 'Invalid transition did not terminate state.' );
+	} catch ( ExperimentsCommandTestError $error ) {
+		experiments_command_test_assert_same( 'Experiment lifecycle transition is invalid.', $error->getMessage(), 'Invalid transition errors must propagate unchanged.' );
+	}
+
+	$registry = file_get_contents( dirname( __DIR__ ) . '/inc/CommandRegistry.php' );
+	experiments_command_test_assert_contains( "'extrachill experiments'", $registry, 'Experiments command group must be registered.' );
+
+	fwrite( STDOUT, "ExperimentsCommand tests passed.\n" );
+}

--- a/tests/ExperimentsOwnerContractTest.php
+++ b/tests/ExperimentsOwnerContractTest.php
@@ -1,0 +1,35 @@
+<?php
+/**
+ * Source-level integration contract with Network's private experiment Abilities.
+ */
+
+$root     = dirname( __DIR__ );
+$fixture  = json_decode( file_get_contents( __DIR__ . '/network-experiment-cli-contract.fixture.json' ), true );
+$command  = file_get_contents( $root . '/inc/Commands/Experiments/ExperimentsCommand.php' );
+$readme   = file_get_contents( $root . '/README.md' );
+$failures = array();
+
+$check = static function ( $condition, $message ) use ( &$failures ) {
+	if ( ! $condition ) {
+		$failures[] = $message;
+	}
+};
+
+$check( is_array( $fixture ), 'Network integration fixture must be valid JSON.' );
+$check( true === $fixture['permission']['trusted_local_wp_cli'], 'Contract must require trusted local WP-CLI permission.' );
+$check( false === $fixture['permission']['user_zero_outside_wp_cli'], 'Contract must deny user zero outside WP-CLI.' );
+$check( 'manage_network_options' === $fixture['permission']['web_capability'], 'Web/REST permission must remain manage_network_options.' );
+$check( false !== strpos( $command, "'extrachill/list-experiments'" ), 'Command must use Network list Ability exactly.' );
+$check( false !== strpos( $command, "'extrachill/transition-experiment-state'" ), 'Command must use Network transition Ability exactly.' );
+$check( false !== strpos( $command, "['registered']" ) && false !== strpos( $command, "['orphaned']" ), 'Command must consume both owner registry-status fields.' );
+$check( false === strpos( $command, 'current_user_can' ), 'CLI must not duplicate Network permission logic.' );
+$check( false === strpos( $command, 'manage_network_options' ), 'CLI must not duplicate Network capability checks.' );
+$check( false !== strpos( $readme, $fixture['standard_invocation'] ), 'README must document the standard trusted local invocation.' );
+$check( false !== strpos( $command, $fixture['standard_invocation'] ), 'Command help must document the standard trusted local invocation.' );
+
+if ( ! empty( $failures ) ) {
+	fwrite( STDERR, implode( "\n", $failures ) . "\n" );
+	exit( 1 );
+}
+
+fwrite( STDOUT, "ExperimentsOwnerContract tests passed.\n" );

--- a/tests/network-experiment-cli-contract.fixture.json
+++ b/tests/network-experiment-cli-contract.fixture.json
@@ -1,0 +1,17 @@
+{
+  "owner": "Extra-Chill/extrachill-network#141",
+  "abilities": {
+    "list": "extrachill/list-experiments",
+    "transition": "extrachill/transition-experiment-state"
+  },
+  "permission": {
+    "trusted_local_wp_cli": true,
+    "web_capability": "manage_network_options",
+    "user_zero_outside_wp_cli": false
+  },
+  "list_status_fields": [
+    "registered",
+    "orphaned"
+  ],
+  "standard_invocation": "wp --allow-root --path=/var/www/extrachill.com extrachill experiments list"
+}


### PR DESCRIPTION
## Summary
- add `wp extrachill experiments list|get|state|report` as thin adapters over the Network lifecycle and Analytics summary Abilities
- preserve complete typed owner envelopes in JSON and every owner field in CSV while presenting definition, lifecycle/no-op, ITT, descriptive exposure, outcomes, confidence, owner interpretation, and coverage sections for humans
- require WP-CLI confirmation for activation and completion, with the standard safe `--yes` bypass, while passing owner permission and invalid-transition messages through unchanged
- recognize Network owner rows marked `registered=false` / `orphaned=true` as inspection-only and reject state/report before confirmation or downstream Ability execution

## Ability Mappings
- `list` and `get` call `extrachill/list-experiments`; `get` selects one complete registered or orphaned owner row without recreating lifecycle logic
- `state` requires a registered owner row, resolves its current definition/version, calls `extrachill/transition-experiment-state` with exactly `experiment_key`, `definition_version`, and `state`, then returns complete before/transition/after owner envelopes
- `report` requires a registered owner row and calls private `extrachill/get-experiment-summary` with required `experiment_key`, `control_variant`, and `variants`
- optional Analytics fields are forwarded only when explicitly supplied: `definition_version`, `outcome_event_types`, `days`, `attribution_window_days`, `session_gap_mins`, and `max_events`; Analytics #212 remains the sole owner of their defaults

## Commands And Output
- `wp extrachill experiments list [--format=table|json|csv]`
- `wp extrachill experiments get <key> [--format=table|json|csv]`
- `wp extrachill experiments state <key> <inactive|active|paused|completed> [--yes] [--format=table|json|csv]`
- `wp extrachill experiments report <key> [--definition-version=<n>] [--control-variant=<id>] [--variants=<csv>] [--outcome-event-types=<csv>] [--days=<n>] [--attribution-window-days=<n>] [--session-gap-mins=<n>] [--max-events=<n>] [--format=table|json|csv]`
- standard trusted local invocation is documented as `wp --allow-root --path=/var/www/extrachill.com extrachill experiments list`, without `--user`
- JSON passes complete owner responses directly to WP-CLI, retaining integers, floats, booleans, nulls, nested data, and future fields
- CSV unions all top-level fields and JSON-encodes nested values, retaining future fields and nested machine types
- human definition output distinguishes registered definitions from orphaned lifecycle records and labels inactive/paused/completed/orphaned rows as runtime no-ops
- human report output renders Analytics' complete `contract`, `window`, and `query`/bounds envelopes, including the owner warning that exposure-conditioned outcomes are descriptive and may be selection-biased; it never converts unknown/null to zero or declares a winner

## Permission And Errors
- Network #141 owns authorization and is coordinated to allow trusted local `WP_CLI` execution while retaining `manage_network_options` for web/REST contexts and denying user zero outside WP-CLI
- `tests/network-experiment-cli-contract.fixture.json` and `ExperimentsOwnerContractTest.php` lock the exact Ability IDs, permission boundary, owner status fields, standard invocation, and absence of duplicated capability logic in CLI
- transitions to `active` and `completed` call `WP_CLI::confirm()` with the full assoc-arg set, preserving WP-CLI's noninteractive `--yes` convention
- owner-reported orphan rows fail state/report before confirmation and before transition/report Ability execution
- Ability permission, validation, and invalid-transition error messages are emitted unchanged through the repository's standard `WP_CLI::error( $result->get_error_message() )` pattern

## Compatibility
- depends on Extra-Chill/extrachill-network#141 and Extra-Chill/extrachill-analytics#212
- duplicates no permission, definition registration, lifecycle option access, transition policy, allocation, persistence, statistics, confidence, lift, report default, or winner logic
- adds focused behavior and owner source-contract suites to the Homeboy test umbrella; no version or changelog files changed

## Verification
- `php tests/ExperimentsCommandTest.php`
- `php tests/ExperimentsOwnerContractTest.php`
- `for test in tests/*Test.php; do php \"$test\" || exit 1; done` (12 standalone suites pass)
- `php -l inc/Commands/Experiments/ExperimentsCommand.php`
- `php -l tests/ExperimentsCommandTest.php`
- `php -l tests/ExperimentsOwnerContractTest.php`
- `phpcs --standard=WordPress --extensions=php inc/CommandRegistry.php inc/Commands/Experiments/ExperimentsCommand.php tests/ExperimentsCommandTest.php tests/ExperimentsOwnerContractTest.php`
- `jq empty homeboy.json tests/network-experiment-cli-contract.fixture.json`
- `git diff --check`

Closes #114