### PR TITLE
fix: omit input for no-schema experiment abilities

### DIFF
--- a/inc/Commands/Experiments/ExperimentsCommand.php
+++ b/inc/Commands/Experiments/ExperimentsCommand.php
@@ -49,7 +49,7 @@ class ExperimentsCommand {
 	 * @when after_wp_load
 	 */
 	public function list_( $args, $assoc_args ) {
-		$result = $this->execute( 'extrachill/list-experiments', array(), 'Extra Chill Network' );
+		$result = $this->execute( 'extrachill/list-experiments', null, 'Extra Chill Network' );
 		$format = $assoc_args['format'] ?? 'table';
 
 		if ( 'json' === $format ) {
@@ -278,12 +278,12 @@ class ExperimentsCommand {
 	}
 
 	/** Execute one owner ability and preserve its error message. */
-	private function execute( $name, array $input, $owner ) {
+	private function execute( $name, $input, $owner ) {
 		$ability = wp_get_ability( $name );
 		if ( ! $ability ) {
 			WP_CLI::error( sprintf( '%s ability not found. Is %s active and up to date?', $name, $owner ) );
 		}
-		$result = $ability->execute( $input );
+		$result = null === $input ? $ability->execute() : $ability->execute( $input );
 		if ( is_wp_error( $result ) ) {
 			WP_CLI::error( $result->get_error_message() );
 		}
@@ -292,7 +292,7 @@ class ExperimentsCommand {
 
 	/** Find one complete definition envelope through Network's list ability. */
 	private function definition( $key ) {
-		foreach ( $this->execute( 'extrachill/list-experiments', array(), 'Extra Chill Network' ) as $definition ) {
+		foreach ( $this->execute( 'extrachill/list-experiments', null, 'Extra Chill Network' ) as $definition ) {
 			if ( (string) ( $definition['key'] ?? '' ) === (string) $key ) {
 				return $definition;
 			}

--- a/tests/ExperimentsCommandTest.php
+++ b/tests/ExperimentsCommandTest.php
@@ -45,15 +45,17 @@ namespace {
 	}
 
 	class ExperimentsCommandTestAbility {
-		public $inputs = array();
+		public $inputs          = array();
+		public $argument_counts = array();
 		private $callback;
 
 		public function __construct( $callback ) {
 			$this->callback = $callback;
 		}
 
-		public function execute( $input ) {
-			$this->inputs[] = $input;
+		public function execute( $input = null ) {
+			$this->argument_counts[] = func_num_args();
+			$this->inputs[]          = $input;
 			return call_user_func( $this->callback, $input );
 		}
 	}
@@ -237,6 +239,7 @@ namespace {
 
 	// List/get machine output retains complete typed definitions and future fields.
 	$command->list_( array(), array( 'format' => 'json' ) );
+	experiments_command_test_assert_same( 0, $list_ability->argument_counts[0], 'List must omit input for an Ability without an input schema.' );
 	experiments_command_test_assert_same( $experiments_command_test_definitions, WP_CLI::$printed[0]['value'], 'List JSON must preserve every owner definition.' );
 	experiments_command_test_assert_same( 3, WP_CLI::$printed[0]['value'][0]['definition_version'], 'List JSON versions must remain integers.' );
 	experiments_command_test_assert_same( true, WP_CLI::$printed[0]['value'][0]['future_definition']['typed'], 'List JSON future booleans must remain typed.' );


### PR DESCRIPTION
## Summary
- invoke the no-input Network experiment list Ability without an explicit empty payload
- preserve explicit payload execution for transition and Analytics report Abilities
- verify the actual Ability argument count in the command regression test

## Production failure

`wp extrachill experiments list --format=json` failed after v0.32.0 deployment because an explicit empty array counts as provided input, while `extrachill/list-experiments` intentionally has no input schema.

## Verification
- `php tests/ExperimentsCommandTest.php`
- PHP syntax checks for both modified files

Closes #116