### PR TITLE
fix: consume experiment owner envelope

### DIFF
--- a/inc/Commands/Experiments/ExperimentsCommand.php
+++ b/inc/Commands/Experiments/ExperimentsCommand.php
@@ -49,23 +49,24 @@ class ExperimentsCommand {
 	 * @when after_wp_load
 	 */
 	public function list_( $args, $assoc_args ) {
-		$result = $this->execute( 'extrachill/list-experiments', null, 'Extra Chill Network' );
-		$format = $assoc_args['format'] ?? 'table';
+		$result      = $this->execute( 'extrachill/list-experiments', null, 'Extra Chill Network' );
+		$definitions = (array) ( $result['items'] ?? array() );
+		$format      = $assoc_args['format'] ?? 'table';
 
 		if ( 'json' === $format ) {
 			WP_CLI::print_value( $result, array( 'format' => 'json' ) );
 			return;
 		}
 		if ( 'csv' === $format ) {
-			$this->display_csv( $result );
+			$this->display_csv( $definitions );
 			return;
 		}
 
-		if ( empty( $result ) ) {
+		if ( empty( $definitions ) ) {
 			WP_CLI::log( 'No registered experiments.' );
 			return;
 		}
-		foreach ( $result as $definition ) {
+		foreach ( $definitions as $definition ) {
 			$this->display_definition( (array) $definition );
 		}
 	}
@@ -292,7 +293,8 @@ class ExperimentsCommand {
 
 	/** Find one complete definition envelope through Network's list ability. */
 	private function definition( $key ) {
-		foreach ( $this->execute( 'extrachill/list-experiments', null, 'Extra Chill Network' ) as $definition ) {
+		$result = $this->execute( 'extrachill/list-experiments', null, 'Extra Chill Network' );
+		foreach ( (array) ( $result['items'] ?? array() ) as $definition ) {
 			if ( (string) ( $definition['key'] ?? '' ) === (string) $key ) {
 				return $definition;
 			}

--- a/tests/ExperimentsCommandTest.php
+++ b/tests/ExperimentsCommandTest.php
@@ -162,7 +162,13 @@ namespace {
 
 	$list_ability = new ExperimentsCommandTestAbility(
 		static function () use ( &$experiments_command_test_definitions ) {
-			return $experiments_command_test_definitions;
+			return array(
+				'items'                    => $experiments_command_test_definitions,
+				'registered_count'         => 2,
+				'orphan_count'             => 1,
+				'orphan_samples_truncated' => false,
+				'lifecycle_over_bound'     => false,
+			);
 		}
 	);
 	$transition_ability = new ExperimentsCommandTestAbility(
@@ -240,9 +246,10 @@ namespace {
 	// List/get machine output retains complete typed definitions and future fields.
 	$command->list_( array(), array( 'format' => 'json' ) );
 	experiments_command_test_assert_same( 0, $list_ability->argument_counts[0], 'List must omit input for an Ability without an input schema.' );
-	experiments_command_test_assert_same( $experiments_command_test_definitions, WP_CLI::$printed[0]['value'], 'List JSON must preserve every owner definition.' );
-	experiments_command_test_assert_same( 3, WP_CLI::$printed[0]['value'][0]['definition_version'], 'List JSON versions must remain integers.' );
-	experiments_command_test_assert_same( true, WP_CLI::$printed[0]['value'][0]['future_definition']['typed'], 'List JSON future booleans must remain typed.' );
+	experiments_command_test_assert_same( $experiments_command_test_definitions, WP_CLI::$printed[0]['value']['items'], 'List JSON must preserve every owner definition.' );
+	experiments_command_test_assert_same( 2, WP_CLI::$printed[0]['value']['registered_count'], 'List JSON must preserve owner bounds diagnostics.' );
+	experiments_command_test_assert_same( 3, WP_CLI::$printed[0]['value']['items'][0]['definition_version'], 'List JSON versions must remain integers.' );
+	experiments_command_test_assert_same( true, WP_CLI::$printed[0]['value']['items'][0]['future_definition']['typed'], 'List JSON future booleans must remain typed.' );
 	experiments_command_test_reset_output();
 	$command->list_( array(), array( 'format' => 'csv' ) );
 	$csv = $experiments_command_test_formats[0];


### PR DESCRIPTION
## Summary
- read definitions from Network's bounded `items` envelope for lookup and human/CSV rendering
- preserve the complete owner envelope for JSON output
- update regression fixtures to model live Network counts and bounds diagnostics

## Production failure

After v0.32.1 fixed no-input Ability invocation, list JSON succeeded but report/get/state lookups iterated the top-level owner envelope and claimed registered experiments were missing.

## Verification
- `php tests/ExperimentsCommandTest.php`
- PHP syntax checks for both modified files

Closes #118