### PR TITLE
fix: make concert commands state-safe

### DIFF
--- a/homeboy.json
+++ b/homeboy.json
@@ -18,6 +18,7 @@
       "php tests/SummaryCommandTest.php",
       "php tests/RetentionCommandTest.php",
       "php tests/UserLocalSceneCommandTest.php",
+      "php tests/ConcertTrackingCommandTest.php",
       "php tests/RevenueCommandTest.php",
       "php tests/RevenueCommandRuntimeTest.php"
     ]

--- a/inc/Commands/Events/ConcertTrackingCommand.php
+++ b/inc/Commands/Events/ConcertTrackingCommand.php
@@ -50,7 +50,7 @@ class ConcertTrackingCommand {
 		$event_id = (int) $args[0];
 		$user     = $this->resolve_user( $assoc_args );
 
-		$this->validate_event( $event_id );
+		$this->require_event( $event_id );
 		$this->ensure_cli_actor();
 
 		$ability = wp_get_ability( 'extrachill/set-event-mark' );
@@ -102,7 +102,7 @@ class ConcertTrackingCommand {
 		$event_id = (int) $args[0];
 		$user     = $this->resolve_user( $assoc_args );
 
-		$this->validate_event( $event_id );
+		$this->require_event( $event_id );
 		$this->ensure_cli_actor();
 
 		$ability = wp_get_ability( 'extrachill/set-event-mark' );
@@ -158,7 +158,7 @@ class ConcertTrackingCommand {
 		$event_id = (int) $args[0];
 		$user     = $this->resolve_user( $assoc_args );
 		$format   = $assoc_args['format'] ?? 'table';
-		$this->validate_event( $event_id );
+		$this->require_event( $event_id );
 		$this->ensure_cli_actor();
 
 		$ability = wp_get_ability( 'extrachill/get-event-attendance' );
@@ -466,7 +466,7 @@ class ConcertTrackingCommand {
 		$event_id = (int) $args[0];
 		$format   = $assoc_args['format'] ?? 'table';
 
-		$this->validate_event( $event_id );
+		$this->require_event( $event_id );
 
 		$ability = wp_get_ability( 'extrachill/get-event-attendance' );
 		if ( ! $ability ) {
@@ -576,11 +576,15 @@ class ConcertTrackingCommand {
 		$invalid = 0;
 
 		foreach ( $event_ids as $event_id ) {
-			$post = $this->validate_event( $event_id, false );
-			if ( ! $post ) {
-				WP_CLI::warning( sprintf( 'Event %d: not found or wrong post type. Skipping.', $event_id ) );
-				++$invalid;
-				continue;
+			$post = $this->validate_event( $event_id );
+			if ( is_wp_error( $post ) ) {
+				if ( $this->is_row_event_error( $post ) ) {
+					WP_CLI::warning( sprintf( 'Event %d: %s Skipping.', $event_id, $post->get_error_message() ) );
+					++$invalid;
+					continue;
+				}
+
+				WP_CLI::error( sprintf( 'Event %d: %s', $event_id, $post->get_error_message() ) );
 			}
 
 			if ( $dry_run ) {
@@ -646,24 +650,26 @@ class ConcertTrackingCommand {
 		return function_exists( 'ec_get_blog_id' ) ? ec_get_blog_id( 'events' ) : 7;
 	}
 
-	private function validate_event( $event_id, $fatal = true ) {
+	private function validate_event( $event_id ) {
 		$events_blog_id = $this->get_events_blog_id();
 		$switched       = get_current_blog_id() !== $events_blog_id;
 
 		if ( $events_blog_id <= 0 || ( $switched && ! switch_to_blog( $events_blog_id ) ) ) {
-			if ( $fatal ) {
-				WP_CLI::error( 'The canonical Events site is unavailable.' );
-			}
-			return null;
+			return new \WP_Error( 'events_site_unavailable', 'The canonical Events site is unavailable.' );
 		}
 
 		try {
 			$post = get_post( $event_id );
-			if ( ! $post || 'data_machine_events' !== $post->post_type || 'publish' !== $post->post_status ) {
-				if ( $fatal ) {
-					WP_CLI::error( sprintf( 'Published event %d not found on the canonical Events site.', $event_id ) );
-				}
-				return null;
+			if ( ! $post ) {
+				return new \WP_Error( 'event_not_found', 'The requested event does not exist on the canonical Events site.' );
+			}
+
+			if ( 'data_machine_events' !== $post->post_type ) {
+				return new \WP_Error( 'invalid_event_post_type', 'The requested post is not an event.' );
+			}
+
+			if ( 'publish' !== $post->post_status ) {
+				return new \WP_Error( 'event_not_published', 'Attendance can only be recorded for published events.' );
 			}
 
 			return $post;
@@ -672,6 +678,15 @@ class ConcertTrackingCommand {
 				restore_current_blog();
 			}
 		}
+	}
+
+	private function require_event( $event_id ) {
+		$event = $this->validate_event( $event_id );
+		if ( is_wp_error( $event ) ) {
+			WP_CLI::error( $event->get_error_message() );
+		}
+
+		return $event;
 	}
 
 	private function is_row_event_error( $error ) {

--- a/inc/Commands/Events/ConcertTrackingCommand.php
+++ b/inc/Commands/Events/ConcertTrackingCommand.php
@@ -158,6 +158,7 @@ class ConcertTrackingCommand {
 		$event_id = (int) $args[0];
 		$user     = $this->resolve_user( $assoc_args );
 		$format   = $assoc_args['format'] ?? 'table';
+		$this->validate_event( $event_id );
 		$this->ensure_cli_actor();
 
 		$ability = wp_get_ability( 'extrachill/get-event-attendance' );
@@ -575,8 +576,8 @@ class ConcertTrackingCommand {
 		$invalid = 0;
 
 		foreach ( $event_ids as $event_id ) {
-			$post = get_post( $event_id );
-			if ( ! $post || 'data_machine_events' !== $post->post_type ) {
+			$post = $this->validate_event( $event_id, false );
+			if ( ! $post ) {
 				WP_CLI::warning( sprintf( 'Event %d: not found or wrong post type. Skipping.', $event_id ) );
 				++$invalid;
 				continue;
@@ -589,9 +590,13 @@ class ConcertTrackingCommand {
 				) );
 
 				if ( is_wp_error( $check ) ) {
-					WP_CLI::warning( sprintf( 'Event %d: %s', $event_id, $check->get_error_message() ) );
-					++$invalid;
-					continue;
+					if ( $this->is_row_event_error( $check ) ) {
+						WP_CLI::warning( sprintf( 'Event %d: %s', $event_id, $check->get_error_message() ) );
+						++$invalid;
+						continue;
+					}
+
+					WP_CLI::error( sprintf( 'Event %d: %s', $event_id, $check->get_error_message() ) );
 				}
 
 				if ( ! empty( $check['user_marked'] ) ) {
@@ -611,9 +616,13 @@ class ConcertTrackingCommand {
 				) );
 
 				if ( is_wp_error( $result ) ) {
-					WP_CLI::warning( sprintf( 'Event %d: %s', $event_id, $result->get_error_message() ) );
-					++$invalid;
-					continue;
+					if ( $this->is_row_event_error( $result ) ) {
+						WP_CLI::warning( sprintf( 'Event %d: %s', $event_id, $result->get_error_message() ) );
+						++$invalid;
+						continue;
+					}
+
+					WP_CLI::error( sprintf( 'Event %d: %s', $event_id, $result->get_error_message() ) );
 				}
 
 				if ( empty( $result['changed'] ) ) {
@@ -637,11 +646,40 @@ class ConcertTrackingCommand {
 		return function_exists( 'ec_get_blog_id' ) ? ec_get_blog_id( 'events' ) : 7;
 	}
 
-	private function validate_event( $event_id ) {
-		$post = get_post( $event_id );
-		if ( ! $post ) {
-			WP_CLI::error( sprintf( 'Event %d not found.', $event_id ) );
+	private function validate_event( $event_id, $fatal = true ) {
+		$events_blog_id = $this->get_events_blog_id();
+		$switched       = get_current_blog_id() !== $events_blog_id;
+
+		if ( $events_blog_id <= 0 || ( $switched && ! switch_to_blog( $events_blog_id ) ) ) {
+			if ( $fatal ) {
+				WP_CLI::error( 'The canonical Events site is unavailable.' );
+			}
+			return null;
 		}
+
+		try {
+			$post = get_post( $event_id );
+			if ( ! $post || 'data_machine_events' !== $post->post_type || 'publish' !== $post->post_status ) {
+				if ( $fatal ) {
+					WP_CLI::error( sprintf( 'Published event %d not found on the canonical Events site.', $event_id ) );
+				}
+				return null;
+			}
+
+			return $post;
+		} finally {
+			if ( $switched ) {
+				restore_current_blog();
+			}
+		}
+	}
+
+	private function is_row_event_error( $error ) {
+		return in_array(
+			$error->get_error_code(),
+			array( 'event_not_found', 'invalid_event_post_type', 'event_not_published' ),
+			true
+		);
 	}
 
 	private function timing_label( $timing ) {

--- a/inc/Commands/Events/ConcertTrackingCommand.php
+++ b/inc/Commands/Events/ConcertTrackingCommand.php
@@ -51,16 +51,17 @@ class ConcertTrackingCommand {
 		$user     = $this->resolve_user( $assoc_args );
 
 		$this->validate_event( $event_id );
+		$this->ensure_cli_actor();
 
-		$ability = wp_get_ability( 'extrachill/toggle-event-mark' );
+		$ability = wp_get_ability( 'extrachill/set-event-mark' );
 		if ( ! $ability ) {
-			WP_CLI::error( 'extrachill/toggle-event-mark ability not available. Is extrachill-users active?' );
+			WP_CLI::error( 'extrachill/set-event-mark ability not available. Is extrachill-users up to date?' );
 		}
 
 		$result = $ability->execute( array(
 			'user_id'  => (int) $user->ID,
 			'event_id' => $event_id,
-			'action'   => 'mark',
+			'marked'   => true,
 		) );
 
 		if ( is_wp_error( $result ) ) {
@@ -101,15 +102,18 @@ class ConcertTrackingCommand {
 		$event_id = (int) $args[0];
 		$user     = $this->resolve_user( $assoc_args );
 
-		$ability = wp_get_ability( 'extrachill/toggle-event-mark' );
+		$this->validate_event( $event_id );
+		$this->ensure_cli_actor();
+
+		$ability = wp_get_ability( 'extrachill/set-event-mark' );
 		if ( ! $ability ) {
-			WP_CLI::error( 'extrachill/toggle-event-mark ability not available. Is extrachill-users active?' );
+			WP_CLI::error( 'extrachill/set-event-mark ability not available. Is extrachill-users up to date?' );
 		}
 
 		$result = $ability->execute( array(
 			'user_id'  => (int) $user->ID,
 			'event_id' => $event_id,
-			'action'   => 'unmark',
+			'marked'   => false,
 		) );
 
 		if ( is_wp_error( $result ) ) {
@@ -154,6 +158,7 @@ class ConcertTrackingCommand {
 		$event_id = (int) $args[0];
 		$user     = $this->resolve_user( $assoc_args );
 		$format   = $assoc_args['format'] ?? 'table';
+		$this->ensure_cli_actor();
 
 		$ability = wp_get_ability( 'extrachill/get-event-attendance' );
 		if ( ! $ability ) {
@@ -172,7 +177,7 @@ class ConcertTrackingCommand {
 		$data = array(
 			'event_id' => $event_id,
 			'user'     => $user->user_login,
-			'marked'   => $result['marked'] ?? false,
+			'marked'   => $result['user_marked'] ?? false,
 			'timing'   => $result['timing'] ?? '',
 			'label'    => $this->timing_label( $result['timing'] ?? '' ),
 			'count'    => $result['count'] ?? 0,
@@ -472,7 +477,7 @@ class ConcertTrackingCommand {
 		$include_attendees = isset( $assoc_args['attendees'] );
 		if ( $include_attendees ) {
 			$input['include_attendees'] = true;
-			$input['attendee_limit']    = isset( $assoc_args['limit'] ) ? (int) $assoc_args['limit'] : 20;
+			$input['limit']             = isset( $assoc_args['limit'] ) ? (int) $assoc_args['limit'] : 20;
 		}
 
 		$result = $ability->execute( $input );
@@ -483,7 +488,6 @@ class ConcertTrackingCommand {
 
 		$data = array(
 			'event_id' => $event_id,
-			'title'    => $result['title'] ?? '(unknown)',
 			'timing'   => $result['timing'] ?? '',
 			'label'    => $this->timing_label( $result['timing'] ?? '' ),
 			'count'    => $result['count'] ?? 0,
@@ -502,8 +506,8 @@ class ConcertTrackingCommand {
 
 		$rows = array(
 			array(
-				'Field' => 'Event',
-				'Value' => $data['title'],
+				'Field' => 'Event ID',
+				'Value' => $data['event_id'],
 			),
 			array(
 				'Field' => 'Timing',
@@ -528,8 +532,8 @@ class ConcertTrackingCommand {
 	 * Bulk import event marks for a user (backfill concert history).
 	 *
 	 * Composite CLI-only utility — no single ability covers the full
-	 * import loop (validation, dedup, dry-run). Each mark invokes the
-	 * extrachill/toggle-event-mark ability individually.
+	 * import loop (validation, dedup, dry-run). Reads use the canonical
+	 * attendance ability and writes use the idempotent set-mark ability.
 	 *
 	 * ## OPTIONS
 	 *
@@ -550,9 +554,10 @@ class ConcertTrackingCommand {
 	 * @when after_wp_load
 	 */
 	public function import( $args, $assoc_args ) {
-		$ability = wp_get_ability( 'extrachill/toggle-event-mark' );
-		if ( ! $ability ) {
-			WP_CLI::error( 'extrachill/toggle-event-mark ability not available. Is extrachill-users active?' );
+		$set_ability   = wp_get_ability( 'extrachill/set-event-mark' );
+		$check_ability = wp_get_ability( 'extrachill/get-event-attendance' );
+		if ( ! $set_ability || ! $check_ability ) {
+			WP_CLI::error( 'Canonical concert tracking abilities are not available. Is extrachill-users up to date?' );
 		}
 
 		$user      = $this->resolve_user_by_identifier( $args[0] ?? '' );
@@ -562,6 +567,8 @@ class ConcertTrackingCommand {
 		if ( empty( $event_ids ) ) {
 			WP_CLI::error( 'No event IDs provided.' );
 		}
+
+		$this->ensure_cli_actor();
 
 		$marked  = 0;
 		$skipped = 0;
@@ -576,11 +583,9 @@ class ConcertTrackingCommand {
 			}
 
 			if ( $dry_run ) {
-				// Dry-run: use the ability with action=check to see current state.
-				$check = $ability->execute( array(
+				$check = $check_ability->execute( array(
 					'user_id'  => (int) $user->ID,
 					'event_id' => $event_id,
-					'action'   => 'check',
 				) );
 
 				if ( is_wp_error( $check ) ) {
@@ -589,7 +594,7 @@ class ConcertTrackingCommand {
 					continue;
 				}
 
-				if ( ! empty( $check['marked'] ) ) {
+				if ( ! empty( $check['user_marked'] ) ) {
 					WP_CLI::log( sprintf( 'Event %d: already marked. Skipping.', $event_id ) );
 					++$skipped;
 					continue;
@@ -599,10 +604,10 @@ class ConcertTrackingCommand {
 				WP_CLI::log( sprintf( 'Event %d: would mark (%s — %s)', $event_id, $post->post_title, $timing ) );
 				++$marked;
 			} else {
-				$result = $ability->execute( array(
+				$result = $set_ability->execute( array(
 					'user_id'  => (int) $user->ID,
 					'event_id' => $event_id,
-					'action'   => 'mark',
+					'marked'   => true,
 				) );
 
 				if ( is_wp_error( $result ) ) {
@@ -687,5 +692,25 @@ class ConcertTrackingCommand {
 		}
 
 		return $user;
+	}
+
+	/**
+	 * Give ability permission checks a deterministic actor in bare WP-CLI runs.
+	 */
+	private function ensure_cli_actor() {
+		$current_user = wp_get_current_user();
+		if ( $current_user && $current_user->ID ) {
+			return;
+		}
+
+		$administrator = get_user_by( 'id', 1 );
+		if ( ! $administrator || ! $administrator->ID ) {
+			WP_CLI::error( 'No authenticated CLI user and no administrator account is available.' );
+		}
+
+		wp_set_current_user( (int) $administrator->ID );
+		if ( ! current_user_can( 'manage_network_options' ) ) {
+			WP_CLI::error( 'The default CLI user is not authorized to manage concert attendance.' );
+		}
 	}
 }

--- a/inc/Commands/Events/ConcertTrackingCommand.php
+++ b/inc/Commands/Events/ConcertTrackingCommand.php
@@ -652,9 +652,13 @@ class ConcertTrackingCommand {
 
 	private function validate_event( $event_id ) {
 		$events_blog_id = $this->get_events_blog_id();
-		$switched       = get_current_blog_id() !== $events_blog_id;
 
-		if ( $events_blog_id <= 0 || ( $switched && ! switch_to_blog( $events_blog_id ) ) ) {
+		if ( $events_blog_id <= 0 || ! get_site( $events_blog_id ) ) {
+			return new \WP_Error( 'events_site_unavailable', 'The canonical Events site is unavailable.' );
+		}
+
+		$switched = get_current_blog_id() !== $events_blog_id;
+		if ( $switched && ! switch_to_blog( $events_blog_id ) ) {
 			return new \WP_Error( 'events_site_unavailable', 'The canonical Events site is unavailable.' );
 		}
 

--- a/tests/ConcertTrackingCommandTest.php
+++ b/tests/ConcertTrackingCommandTest.php
@@ -29,10 +29,16 @@ namespace {
 	}
 
 	class ConcertTrackingCommandTestWpError {
+		private $code;
 		private $message;
 
-		public function __construct( $message ) {
+		public function __construct( $code, $message ) {
+			$this->code    = $code;
 			$this->message = $message;
+		}
+
+		public function get_error_code() {
+			return $this->code;
 		}
 
 		public function get_error_message() {
@@ -60,12 +66,22 @@ namespace {
 		8 => array( 'ID' => 8, 'user_login' => 'listener', 'user_email' => 'listener@example.com' ),
 	);
 	$concert_tracking_posts = array(
-		10 => array( 'ID' => 10, 'post_type' => 'data_machine_events', 'post_title' => 'First Show' ),
-		11 => array( 'ID' => 11, 'post_type' => 'data_machine_events', 'post_title' => 'Second Show' ),
+		1 => array(
+			10 => array( 'ID' => 10, 'post_type' => 'post', 'post_status' => 'publish', 'post_title' => 'Colliding Main Post' ),
+			12 => array( 'ID' => 12, 'post_type' => 'data_machine_events', 'post_status' => 'publish', 'post_title' => 'Main-Site Event' ),
+		),
+		7 => array(
+			10 => array( 'ID' => 10, 'post_type' => 'data_machine_events', 'post_status' => 'publish', 'post_title' => 'First Show' ),
+			11 => array( 'ID' => 11, 'post_type' => 'data_machine_events', 'post_status' => 'publish', 'post_title' => 'Second Show' ),
+		),
 	);
 	$concert_tracking_current_user_id = 0;
+	$concert_tracking_current_blog_id = 1;
+	$concert_tracking_blog_stack      = array();
 	$concert_tracking_marks           = array();
 	$concert_tracking_abilities       = array();
+	$concert_tracking_set_error       = null;
+	$concert_tracking_check_error     = null;
 
 	function get_user_by( $field, $value ) {
 		global $concert_tracking_users;
@@ -94,8 +110,33 @@ namespace {
 	}
 
 	function get_post( $post_id ) {
-		global $concert_tracking_posts;
-		return isset( $concert_tracking_posts[ $post_id ] ) ? (object) $concert_tracking_posts[ $post_id ] : null;
+		global $concert_tracking_current_blog_id, $concert_tracking_posts;
+		return isset( $concert_tracking_posts[ $concert_tracking_current_blog_id ][ $post_id ] ) ? (object) $concert_tracking_posts[ $concert_tracking_current_blog_id ][ $post_id ] : null;
+	}
+
+	function get_current_blog_id() {
+		global $concert_tracking_current_blog_id;
+		return $concert_tracking_current_blog_id;
+	}
+
+	function switch_to_blog( $blog_id ) {
+		global $concert_tracking_blog_stack, $concert_tracking_current_blog_id, $concert_tracking_posts;
+		if ( ! isset( $concert_tracking_posts[ $blog_id ] ) ) {
+			return false;
+		}
+		$concert_tracking_blog_stack[] = $concert_tracking_current_blog_id;
+		$concert_tracking_current_blog_id = (int) $blog_id;
+		return true;
+	}
+
+	function restore_current_blog() {
+		global $concert_tracking_blog_stack, $concert_tracking_current_blog_id;
+		$concert_tracking_current_blog_id = array_pop( $concert_tracking_blog_stack );
+		return true;
+	}
+
+	function ec_get_blog_id( $site ) {
+		return 'events' === $site ? 7 : 1;
 	}
 
 	function wp_get_ability( $name ) {
@@ -142,12 +183,15 @@ namespace {
 
 	use ExtraChill\CLI\Commands\Events\ConcertTrackingCommand;
 
-	global $concert_tracking_abilities, $concert_tracking_current_user_id, $concert_tracking_formats, $concert_tracking_marks;
+	global $concert_tracking_abilities, $concert_tracking_check_error, $concert_tracking_current_blog_id, $concert_tracking_current_user_id, $concert_tracking_formats, $concert_tracking_marks, $concert_tracking_set_error;
 
 	$set_ability = new ConcertTrackingCommandTestAbility(
-		static function ( $input ) use ( &$concert_tracking_marks, &$concert_tracking_current_user_id ) {
+		static function ( $input ) use ( &$concert_tracking_marks, &$concert_tracking_current_user_id, &$concert_tracking_set_error ) {
+			if ( $concert_tracking_set_error ) {
+				return $concert_tracking_set_error;
+			}
 			if ( $input['user_id'] !== $concert_tracking_current_user_id && 1 !== $concert_tracking_current_user_id ) {
-				return new ConcertTrackingCommandTestWpError( 'Not authorized for target user.' );
+				return new ConcertTrackingCommandTestWpError( 'ability_invalid_permissions', 'Not authorized for target user.' );
 			}
 			$key      = $input['user_id'] . ':' . $input['event_id'];
 			$before   = ! empty( $concert_tracking_marks[ $key ] );
@@ -158,9 +202,12 @@ namespace {
 		}
 	);
 	$check_ability = new ConcertTrackingCommandTestAbility(
-		static function ( $input ) use ( &$concert_tracking_marks, &$concert_tracking_current_user_id ) {
+		static function ( $input ) use ( &$concert_tracking_marks, &$concert_tracking_current_user_id, &$concert_tracking_check_error ) {
+			if ( $concert_tracking_check_error ) {
+				return $concert_tracking_check_error;
+			}
 			if ( isset( $input['user_id'] ) && $input['user_id'] !== $concert_tracking_current_user_id && 1 !== $concert_tracking_current_user_id ) {
-				return new ConcertTrackingCommandTestWpError( 'Not authorized for target user.' );
+				return new ConcertTrackingCommandTestWpError( 'ability_invalid_permissions', 'Not authorized for target user.' );
 			}
 			$key = ( $input['user_id'] ?? $concert_tracking_current_user_id ) . ':' . $input['event_id'];
 			return array(
@@ -182,6 +229,7 @@ namespace {
 	// Bare WP-CLI execution adopts the administrator as actor while retaining the explicit target.
 	$command->mark( array( 10 ), array( 'user' => 'chubes' ) );
 	$command->mark( array( 10 ), array( 'user' => 'chubes' ) );
+	concert_tracking_assert_same( 1, $concert_tracking_current_blog_id, 'Mark must restore the main-site invocation context.' );
 	concert_tracking_assert_same( 1, $concert_tracking_current_user_id, 'Bare CLI execution must establish the deterministic administrator actor.' );
 	concert_tracking_assert_same( true, $concert_tracking_marks['7:10'], 'Repeated marks must leave the event marked.' );
 	concert_tracking_assert_same( array( 'user_id' => 7, 'event_id' => 10, 'marked' => true ), $set_ability->inputs[0], 'Mark must use the canonical desired-state contract.' );
@@ -190,12 +238,14 @@ namespace {
 	WP_CLI::$messages = array();
 	$command->unmark( array( 11 ), array( 'user' => 'chubes' ) );
 	$command->unmark( array( 11 ), array( 'user' => 'chubes' ) );
+	concert_tracking_assert_same( 1, $concert_tracking_current_blog_id, 'Unmark must restore the main-site invocation context.' );
 	concert_tracking_assert_same( false, $concert_tracking_marks['7:11'], 'Repeated unmarks must leave the event unmarked.' );
 	concert_tracking_assert_contains( 'was not marked', implode( "\n", WP_CLI::$messages ), 'Repeated unmark must report an unchanged state.' );
 
 	$writes_before = count( $set_ability->inputs );
 	$command->check( array( 10 ), array( 'user' => 'chubes' ) );
 	$command->check( array( 10 ), array( 'user' => 'listener' ) );
+	concert_tracking_assert_same( 1, $concert_tracking_current_blog_id, 'Check must restore the main-site invocation context.' );
 	concert_tracking_assert_same( $writes_before, count( $set_ability->inputs ), 'Checks for any user must not execute a mutation ability.' );
 	concert_tracking_assert_same( array( 'event_id' => 10, 'user_id' => 8 ), $check_ability->inputs[1], 'Check must pass the selected user explicitly.' );
 
@@ -207,23 +257,56 @@ namespace {
 
 	WP_CLI::$messages = array();
 	$command->import( array( 'chubes', '10,11,11' ), array() );
+	concert_tracking_assert_same( 1, $concert_tracking_current_blog_id, 'Import must restore the main-site invocation context.' );
 	concert_tracking_assert_same( true, $concert_tracking_marks['7:11'], 'Import must idempotently mark unmarked events.' );
 	concert_tracking_assert_contains( 'Marked 1 events for chubes. Skipped: 2. Invalid: 0.', implode( "\n", WP_CLI::$messages ), 'Import counts must reflect actual changes and repeated IDs.' );
 
 	$concert_tracking_formats = array();
 	$command->event( array( 10 ), array( 'attendees' => true, 'limit' => 3 ) );
+	concert_tracking_assert_same( 1, $concert_tracking_current_blog_id, 'Event detail must restore the main-site invocation context.' );
 	$event_input = end( $check_ability->inputs );
 	concert_tracking_assert_same( array( 'event_id' => 10, 'include_attendees' => true, 'limit' => 3 ), $event_input, 'Event detail must pass the canonical limit field.' );
 	concert_tracking_assert_same( 'Event ID', $concert_tracking_formats[0]['items'][0]['Field'], 'Event detail must present a field backed by the ability contract.' );
 
-	// A non-admin actor cannot silently target another user.
+	// A colliding event ID that exists only on the invocation site must be rejected.
+	$writes_before = count( $set_ability->inputs );
+	try {
+		$command->mark( array( 12 ), array( 'user' => 'chubes' ) );
+		throw new \RuntimeException( 'Wrong-site event IDs should fail.' );
+	} catch ( ConcertTrackingCommandTestError $error ) {
+		concert_tracking_assert_contains( 'canonical Events site', $error->getMessage(), 'Validation must reject invocation-site posts.' );
+	}
+	concert_tracking_assert_same( $writes_before, count( $set_ability->inputs ), 'Wrong-site IDs must fail before ability execution.' );
+	concert_tracking_assert_same( 1, $concert_tracking_current_blog_id, 'Failed validation must restore the invocation context.' );
+
+	// Unauthorized import failures must exit nonzero instead of reporting success.
 	wp_set_current_user( 8 );
 	try {
-		$command->mark( array( 10 ), array( 'user' => 'chubes' ) );
-		throw new \RuntimeException( 'Unauthorized targeting should fail.' );
+		$command->import( array( 'chubes', '10' ), array( 'dry-run' => true ) );
+		throw new \RuntimeException( 'Unauthorized import should fail.' );
 	} catch ( ConcertTrackingCommandTestError $error ) {
-		concert_tracking_assert_contains( 'Not authorized', $error->getMessage(), 'Unauthorized targeting must fail clearly.' );
+		concert_tracking_assert_contains( 'Not authorized', $error->getMessage(), 'Unauthorized import must fail clearly.' );
 	}
+
+	// Missing dependencies and systemic ability errors must also exit nonzero.
+	wp_set_current_user( 1 );
+	unset( $concert_tracking_abilities['extrachill/set-event-mark'] );
+	try {
+		$command->import( array( 'chubes', '10' ), array() );
+		throw new \RuntimeException( 'Missing dependency should fail.' );
+	} catch ( ConcertTrackingCommandTestError $error ) {
+		concert_tracking_assert_contains( 'not available', $error->getMessage(), 'Missing canonical abilities must fail clearly.' );
+	}
+	$concert_tracking_abilities['extrachill/set-event-mark'] = $set_ability;
+
+	$concert_tracking_set_error = new ConcertTrackingCommandTestWpError( 'database_unavailable', 'Attendance storage unavailable.' );
+	try {
+		$command->import( array( 'chubes', '10' ), array() );
+		throw new \RuntimeException( 'Systemic ability failure should fail.' );
+	} catch ( ConcertTrackingCommandTestError $error ) {
+		concert_tracking_assert_contains( 'Attendance storage unavailable', $error->getMessage(), 'Systemic failures must fail the import.' );
+	}
+	$concert_tracking_set_error = null;
 
 	fwrite( STDOUT, "ConcertTrackingCommand tests passed.\n" );
 }

--- a/tests/ConcertTrackingCommandTest.php
+++ b/tests/ConcertTrackingCommandTest.php
@@ -75,6 +75,7 @@ namespace {
 			11 => array( 'ID' => 11, 'post_type' => 'data_machine_events', 'post_status' => 'publish', 'post_title' => 'Second Show' ),
 		),
 	);
+	$concert_tracking_sites           = array( 1, 7 );
 	$concert_tracking_current_user_id = 0;
 	$concert_tracking_current_blog_id = 1;
 	$concert_tracking_events_blog_id  = 7;
@@ -121,13 +122,15 @@ namespace {
 	}
 
 	function switch_to_blog( $blog_id ) {
-		global $concert_tracking_blog_stack, $concert_tracking_current_blog_id, $concert_tracking_posts;
-		if ( ! isset( $concert_tracking_posts[ $blog_id ] ) ) {
-			return false;
-		}
+		global $concert_tracking_blog_stack, $concert_tracking_current_blog_id;
 		$concert_tracking_blog_stack[] = $concert_tracking_current_blog_id;
 		$concert_tracking_current_blog_id = (int) $blog_id;
 		return true;
+	}
+
+	function get_site( $blog_id ) {
+		global $concert_tracking_sites;
+		return in_array( (int) $blog_id, $concert_tracking_sites, true ) ? (object) array( 'blog_id' => (int) $blog_id ) : null;
 	}
 
 	function restore_current_blog() {
@@ -288,6 +291,11 @@ namespace {
 	concert_tracking_assert_same( 1, $concert_tracking_current_blog_id, 'Skipped row validation must restore the invocation context.' );
 
 	// Canonical site resolution failures are fatal for direct commands and imports.
+	concert_tracking_assert_same( true, switch_to_blog( 99 ), 'The test double must match WordPress core behavior for nonexistent site IDs.' );
+	concert_tracking_assert_same( 99, $concert_tracking_current_blog_id, 'Core switch behavior must not validate site existence.' );
+	restore_current_blog();
+	concert_tracking_assert_same( 1, $concert_tracking_current_blog_id, 'The core-behavior probe must restore invocation context.' );
+
 	$concert_tracking_events_blog_id = 99;
 	try {
 		$command->check( array( 10 ), array( 'user' => 'chubes' ) );

--- a/tests/ConcertTrackingCommandTest.php
+++ b/tests/ConcertTrackingCommandTest.php
@@ -1,0 +1,229 @@
+<?php
+/**
+ * Focused contract tests for concert tracking CLI adapters.
+ */
+
+namespace {
+	define( 'ABSPATH', __DIR__ . '/' );
+
+	class ConcertTrackingCommandTestError extends \RuntimeException {}
+
+	class WP_CLI {
+		public static $messages = array();
+
+		public static function error( $message ) {
+			throw new ConcertTrackingCommandTestError( $message );
+		}
+
+		public static function success( $message ) {
+			self::$messages[] = 'Success: ' . $message;
+		}
+
+		public static function warning( $message ) {
+			self::$messages[] = 'Warning: ' . $message;
+		}
+
+		public static function log( $message ) {
+			self::$messages[] = $message;
+		}
+	}
+
+	class ConcertTrackingCommandTestWpError {
+		private $message;
+
+		public function __construct( $message ) {
+			$this->message = $message;
+		}
+
+		public function get_error_message() {
+			return $this->message;
+		}
+	}
+
+	class ConcertTrackingCommandTestAbility {
+		public $inputs = array();
+		private $callback;
+
+		public function __construct( $callback ) {
+			$this->callback = $callback;
+		}
+
+		public function execute( $input ) {
+			$this->inputs[] = $input;
+			return call_user_func( $this->callback, $input );
+		}
+	}
+
+	$concert_tracking_users = array(
+		1 => array( 'ID' => 1, 'user_login' => 'admin', 'user_email' => 'admin@example.com' ),
+		7 => array( 'ID' => 7, 'user_login' => 'chubes', 'user_email' => 'chubes@example.com' ),
+		8 => array( 'ID' => 8, 'user_login' => 'listener', 'user_email' => 'listener@example.com' ),
+	);
+	$concert_tracking_posts = array(
+		10 => array( 'ID' => 10, 'post_type' => 'data_machine_events', 'post_title' => 'First Show' ),
+		11 => array( 'ID' => 11, 'post_type' => 'data_machine_events', 'post_title' => 'Second Show' ),
+	);
+	$concert_tracking_current_user_id = 0;
+	$concert_tracking_marks           = array();
+	$concert_tracking_abilities       = array();
+
+	function get_user_by( $field, $value ) {
+		global $concert_tracking_users;
+		foreach ( $concert_tracking_users as $user ) {
+			if ( ( 'id' === $field && (int) $value === $user['ID'] ) || ( 'login' === $field && $value === $user['user_login'] ) || ( 'email' === $field && $value === $user['user_email'] ) ) {
+				return (object) $user;
+			}
+		}
+		return false;
+	}
+
+	function wp_get_current_user() {
+		global $concert_tracking_current_user_id;
+		return $concert_tracking_current_user_id ? get_user_by( 'id', $concert_tracking_current_user_id ) : (object) array( 'ID' => 0 );
+	}
+
+	function wp_set_current_user( $user_id ) {
+		global $concert_tracking_current_user_id;
+		$concert_tracking_current_user_id = (int) $user_id;
+		return wp_get_current_user();
+	}
+
+	function current_user_can( $capability ) {
+		global $concert_tracking_current_user_id;
+		return 'manage_network_options' === $capability && 1 === $concert_tracking_current_user_id;
+	}
+
+	function get_post( $post_id ) {
+		global $concert_tracking_posts;
+		return isset( $concert_tracking_posts[ $post_id ] ) ? (object) $concert_tracking_posts[ $post_id ] : null;
+	}
+
+	function wp_get_ability( $name ) {
+		global $concert_tracking_abilities;
+		return $concert_tracking_abilities[ $name ] ?? null;
+	}
+
+	function is_wp_error( $value ) {
+		return $value instanceof ConcertTrackingCommandTestWpError;
+	}
+
+	function is_email( $value ) {
+		return false !== strpos( $value, '@' );
+	}
+
+	function wp_json_encode( $value, $flags = 0 ) {
+		return json_encode( $value, $flags );
+	}
+
+	function concert_tracking_assert_same( $expected, $actual, $message ) {
+		if ( $expected !== $actual ) {
+			throw new \RuntimeException( $message . '\nExpected: ' . var_export( $expected, true ) . '\nActual: ' . var_export( $actual, true ) );
+		}
+	}
+
+	function concert_tracking_assert_contains( $needle, $haystack, $message ) {
+		if ( false === strpos( $haystack, $needle ) ) {
+			throw new \RuntimeException( $message . '\nMissing: ' . $needle );
+		}
+	}
+}
+
+namespace WP_CLI\Utils {
+	$concert_tracking_formats = array();
+
+	function format_items( $format, $items, $fields ) {
+		global $concert_tracking_formats;
+		$concert_tracking_formats[] = compact( 'format', 'items', 'fields' );
+	}
+}
+
+namespace {
+	require_once dirname( __DIR__ ) . '/inc/Commands/Events/ConcertTrackingCommand.php';
+
+	use ExtraChill\CLI\Commands\Events\ConcertTrackingCommand;
+
+	global $concert_tracking_abilities, $concert_tracking_current_user_id, $concert_tracking_formats, $concert_tracking_marks;
+
+	$set_ability = new ConcertTrackingCommandTestAbility(
+		static function ( $input ) use ( &$concert_tracking_marks, &$concert_tracking_current_user_id ) {
+			if ( $input['user_id'] !== $concert_tracking_current_user_id && 1 !== $concert_tracking_current_user_id ) {
+				return new ConcertTrackingCommandTestWpError( 'Not authorized for target user.' );
+			}
+			$key      = $input['user_id'] . ':' . $input['event_id'];
+			$before   = ! empty( $concert_tracking_marks[ $key ] );
+			$marked   = (bool) $input['marked'];
+			$changed  = $before !== $marked;
+			$concert_tracking_marks[ $key ] = $marked;
+			return array( 'changed' => $changed, 'marked' => $marked, 'timing' => 'past', 'count' => $marked ? 1 : 0 );
+		}
+	);
+	$check_ability = new ConcertTrackingCommandTestAbility(
+		static function ( $input ) use ( &$concert_tracking_marks, &$concert_tracking_current_user_id ) {
+			if ( isset( $input['user_id'] ) && $input['user_id'] !== $concert_tracking_current_user_id && 1 !== $concert_tracking_current_user_id ) {
+				return new ConcertTrackingCommandTestWpError( 'Not authorized for target user.' );
+			}
+			$key = ( $input['user_id'] ?? $concert_tracking_current_user_id ) . ':' . $input['event_id'];
+			return array(
+				'user_marked' => ! empty( $concert_tracking_marks[ $key ] ),
+				'timing'      => 'past',
+				'count'       => ! empty( $concert_tracking_marks[ $key ] ) ? 1 : 0,
+				'count_label' => ! empty( $concert_tracking_marks[ $key ] ) ? '1 was there' : '0 were there',
+				'attendees'   => array(),
+			);
+		}
+	);
+	$concert_tracking_abilities = array(
+		'extrachill/set-event-mark'      => $set_ability,
+		'extrachill/get-event-attendance' => $check_ability,
+	);
+
+	$command = new ConcertTrackingCommand();
+
+	// Bare WP-CLI execution adopts the administrator as actor while retaining the explicit target.
+	$command->mark( array( 10 ), array( 'user' => 'chubes' ) );
+	$command->mark( array( 10 ), array( 'user' => 'chubes' ) );
+	concert_tracking_assert_same( 1, $concert_tracking_current_user_id, 'Bare CLI execution must establish the deterministic administrator actor.' );
+	concert_tracking_assert_same( true, $concert_tracking_marks['7:10'], 'Repeated marks must leave the event marked.' );
+	concert_tracking_assert_same( array( 'user_id' => 7, 'event_id' => 10, 'marked' => true ), $set_ability->inputs[0], 'Mark must use the canonical desired-state contract.' );
+	concert_tracking_assert_contains( 'already marked', implode( "\n", WP_CLI::$messages ), 'Repeated mark must report an unchanged state.' );
+
+	WP_CLI::$messages = array();
+	$command->unmark( array( 11 ), array( 'user' => 'chubes' ) );
+	$command->unmark( array( 11 ), array( 'user' => 'chubes' ) );
+	concert_tracking_assert_same( false, $concert_tracking_marks['7:11'], 'Repeated unmarks must leave the event unmarked.' );
+	concert_tracking_assert_contains( 'was not marked', implode( "\n", WP_CLI::$messages ), 'Repeated unmark must report an unchanged state.' );
+
+	$writes_before = count( $set_ability->inputs );
+	$command->check( array( 10 ), array( 'user' => 'chubes' ) );
+	$command->check( array( 10 ), array( 'user' => 'listener' ) );
+	concert_tracking_assert_same( $writes_before, count( $set_ability->inputs ), 'Checks for any user must not execute a mutation ability.' );
+	concert_tracking_assert_same( array( 'event_id' => 10, 'user_id' => 8 ), $check_ability->inputs[1], 'Check must pass the selected user explicitly.' );
+
+	$snapshot = $concert_tracking_marks;
+	WP_CLI::$messages = array();
+	$command->import( array( 'chubes', '10,11' ), array( 'dry-run' => true ) );
+	concert_tracking_assert_same( $snapshot, $concert_tracking_marks, 'Import dry-run must not mutate attendance.' );
+	concert_tracking_assert_contains( 'Would mark 1 events for chubes. Skipped: 1. Invalid: 0.', implode( "\n", WP_CLI::$messages ), 'Dry-run counts must distinguish changed and skipped events.' );
+
+	WP_CLI::$messages = array();
+	$command->import( array( 'chubes', '10,11,11' ), array() );
+	concert_tracking_assert_same( true, $concert_tracking_marks['7:11'], 'Import must idempotently mark unmarked events.' );
+	concert_tracking_assert_contains( 'Marked 1 events for chubes. Skipped: 2. Invalid: 0.', implode( "\n", WP_CLI::$messages ), 'Import counts must reflect actual changes and repeated IDs.' );
+
+	$concert_tracking_formats = array();
+	$command->event( array( 10 ), array( 'attendees' => true, 'limit' => 3 ) );
+	$event_input = end( $check_ability->inputs );
+	concert_tracking_assert_same( array( 'event_id' => 10, 'include_attendees' => true, 'limit' => 3 ), $event_input, 'Event detail must pass the canonical limit field.' );
+	concert_tracking_assert_same( 'Event ID', $concert_tracking_formats[0]['items'][0]['Field'], 'Event detail must present a field backed by the ability contract.' );
+
+	// A non-admin actor cannot silently target another user.
+	wp_set_current_user( 8 );
+	try {
+		$command->mark( array( 10 ), array( 'user' => 'chubes' ) );
+		throw new \RuntimeException( 'Unauthorized targeting should fail.' );
+	} catch ( ConcertTrackingCommandTestError $error ) {
+		concert_tracking_assert_contains( 'Not authorized', $error->getMessage(), 'Unauthorized targeting must fail clearly.' );
+	}
+
+	fwrite( STDOUT, "ConcertTrackingCommand tests passed.\n" );
+}

--- a/tests/ConcertTrackingCommandTest.php
+++ b/tests/ConcertTrackingCommandTest.php
@@ -28,7 +28,7 @@ namespace {
 		}
 	}
 
-	class ConcertTrackingCommandTestWpError {
+	class WP_Error {
 		private $code;
 		private $message;
 
@@ -77,6 +77,7 @@ namespace {
 	);
 	$concert_tracking_current_user_id = 0;
 	$concert_tracking_current_blog_id = 1;
+	$concert_tracking_events_blog_id  = 7;
 	$concert_tracking_blog_stack      = array();
 	$concert_tracking_marks           = array();
 	$concert_tracking_abilities       = array();
@@ -136,7 +137,8 @@ namespace {
 	}
 
 	function ec_get_blog_id( $site ) {
-		return 'events' === $site ? 7 : 1;
+		global $concert_tracking_events_blog_id;
+		return 'events' === $site ? $concert_tracking_events_blog_id : 1;
 	}
 
 	function wp_get_ability( $name ) {
@@ -145,7 +147,7 @@ namespace {
 	}
 
 	function is_wp_error( $value ) {
-		return $value instanceof ConcertTrackingCommandTestWpError;
+		return $value instanceof WP_Error;
 	}
 
 	function is_email( $value ) {
@@ -183,7 +185,7 @@ namespace {
 
 	use ExtraChill\CLI\Commands\Events\ConcertTrackingCommand;
 
-	global $concert_tracking_abilities, $concert_tracking_check_error, $concert_tracking_current_blog_id, $concert_tracking_current_user_id, $concert_tracking_formats, $concert_tracking_marks, $concert_tracking_set_error;
+	global $concert_tracking_abilities, $concert_tracking_check_error, $concert_tracking_current_blog_id, $concert_tracking_current_user_id, $concert_tracking_events_blog_id, $concert_tracking_formats, $concert_tracking_marks, $concert_tracking_set_error;
 
 	$set_ability = new ConcertTrackingCommandTestAbility(
 		static function ( $input ) use ( &$concert_tracking_marks, &$concert_tracking_current_user_id, &$concert_tracking_set_error ) {
@@ -191,7 +193,7 @@ namespace {
 				return $concert_tracking_set_error;
 			}
 			if ( $input['user_id'] !== $concert_tracking_current_user_id && 1 !== $concert_tracking_current_user_id ) {
-				return new ConcertTrackingCommandTestWpError( 'ability_invalid_permissions', 'Not authorized for target user.' );
+				return new WP_Error( 'ability_invalid_permissions', 'Not authorized for target user.' );
 			}
 			$key      = $input['user_id'] . ':' . $input['event_id'];
 			$before   = ! empty( $concert_tracking_marks[ $key ] );
@@ -207,7 +209,7 @@ namespace {
 				return $concert_tracking_check_error;
 			}
 			if ( isset( $input['user_id'] ) && $input['user_id'] !== $concert_tracking_current_user_id && 1 !== $concert_tracking_current_user_id ) {
-				return new ConcertTrackingCommandTestWpError( 'ability_invalid_permissions', 'Not authorized for target user.' );
+				return new WP_Error( 'ability_invalid_permissions', 'Not authorized for target user.' );
 			}
 			$key = ( $input['user_id'] ?? $concert_tracking_current_user_id ) . ':' . $input['event_id'];
 			return array(
@@ -279,6 +281,31 @@ namespace {
 	concert_tracking_assert_same( $writes_before, count( $set_ability->inputs ), 'Wrong-site IDs must fail before ability execution.' );
 	concert_tracking_assert_same( 1, $concert_tracking_current_blog_id, 'Failed validation must restore the invocation context.' );
 
+	// Invalid rows are skippable and preserve context during import.
+	WP_CLI::$messages = array();
+	$command->import( array( 'chubes', '12' ), array( 'dry-run' => true ) );
+	concert_tracking_assert_contains( 'Would mark 0 events for chubes. Skipped: 0. Invalid: 1.', implode( "\n", WP_CLI::$messages ), 'Invalid event rows must be counted and skipped.' );
+	concert_tracking_assert_same( 1, $concert_tracking_current_blog_id, 'Skipped row validation must restore the invocation context.' );
+
+	// Canonical site resolution failures are fatal for direct commands and imports.
+	$concert_tracking_events_blog_id = 99;
+	try {
+		$command->check( array( 10 ), array( 'user' => 'chubes' ) );
+		throw new \RuntimeException( 'Unavailable canonical site should fail direct commands.' );
+	} catch ( ConcertTrackingCommandTestError $error ) {
+		concert_tracking_assert_contains( 'canonical Events site is unavailable', $error->getMessage(), 'Direct commands must fail when the canonical site is unavailable.' );
+	}
+	concert_tracking_assert_same( 1, $concert_tracking_current_blog_id, 'Unavailable-site validation must preserve invocation context.' );
+
+	try {
+		$command->import( array( 'chubes', '10,11' ), array( 'dry-run' => true ) );
+		throw new \RuntimeException( 'Unavailable canonical site should fail imports.' );
+	} catch ( ConcertTrackingCommandTestError $error ) {
+		concert_tracking_assert_contains( 'canonical Events site is unavailable', $error->getMessage(), 'Import must fail instead of skipping rows when the canonical site is unavailable.' );
+	}
+	concert_tracking_assert_same( 1, $concert_tracking_current_blog_id, 'Failed import site resolution must preserve invocation context.' );
+	$concert_tracking_events_blog_id = 7;
+
 	// Unauthorized import failures must exit nonzero instead of reporting success.
 	wp_set_current_user( 8 );
 	try {
@@ -299,7 +326,7 @@ namespace {
 	}
 	$concert_tracking_abilities['extrachill/set-event-mark'] = $set_ability;
 
-	$concert_tracking_set_error = new ConcertTrackingCommandTestWpError( 'database_unavailable', 'Attendance storage unavailable.' );
+	$concert_tracking_set_error = new WP_Error( 'database_unavailable', 'Attendance storage unavailable.' );
 	try {
 		$command->import( array( 'chubes', '10' ), array() );
 		throw new \RuntimeException( 'Systemic ability failure should fail.' );


### PR DESCRIPTION
## Summary
- replace toggle-based mark/unmark/import writes with the canonical idempotent desired-state ability from Extra-Chill/extrachill-users#222
- resolve events only on the canonical Events site for mark, unmark, check, event detail, and import, always restoring invocation context
- validate canonical site existence with `get_site()` before `switch_to_blog()`, matching WordPress core behavior for stale/nonexistent site IDs
- make check and import dry-run use only authorized attendance reads for the selected user
- terminate imports on authorization, missing dependency, unavailable canonical site, and systemic ability failures; only row-specific invalid event input is skippable
- map event detail to the canonical `limit` input and remove the unsupported title field
- cover main-site invocation, colliding wrong-site IDs, core-accurate site switching, `get_site()` failure, context restoration, import nonzero exits, repeated commands, dry-run immutability, and event parsing

## Dependencies and release order
- Extra-Chill/extrachill-users#224 is merged and integrated into Extra-Chill/extrachill-users#222
- Requires Users #222 to be merged and released before this PR may merge or release
- Final order: Users #222 merge/release -> CLI #121 merge/release

## Verification
- `php -l inc/Commands/Events/ConcertTrackingCommand.php` passed
- `php -l tests/ConcertTrackingCommandTest.php` passed
- `php tests/ConcertTrackingCommandTest.php` passed
- `git diff --check` passed
- `homeboy review extrachill-cli test` and `lint` were attempted but refused by the hot-host resource policy at load average ~144 because no Lab runner was available; local override was not forced

Closes #120