### PR TITLE
refactor: use owner-site ability bootstrap

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,21 @@ wp plugin activate extrachill-cli --network --allow-root
 
 ## Commands
 
+### Multisite Owner Context
+
+Commands backed by site-only abilities must use WP-CLI's native `--url` bootstrap
+for the site that owns those abilities. The CLI does not load another plugin's
+PHP after startup.
+
+```bash
+wp --url=https://events.extrachill.com extrachill events market-report
+wp --url=https://artist.extrachill.com extrachill artists count
+```
+
+Running either command group against another network site exits with the exact
+owner URL. If the owner plugin is inactive or incomplete on that site, the
+command exits with an owner-plugin capability error.
+
 ### Platform Experiments
 
 Inspect registered definitions and orphaned lifecycle records, transition

--- a/homeboy.json
+++ b/homeboy.json
@@ -12,6 +12,7 @@
       "php tests/QRCodeCommandTest.php",
       "php tests/ExperimentsCommandTest.php",
       "php tests/ExperimentsOwnerContractTest.php",
+      "php tests/OwnerSiteAbilityTest.php",
       "php tests/CrosslinkTargetsCommandTest.php",
       "php tests/OutboundCommandTest.php",
       "php tests/ConversionCommandTest.php",

--- a/inc/Commands/Artists/ArtistCommand.php
+++ b/inc/Commands/Artists/ArtistCommand.php
@@ -9,6 +9,7 @@
 
 namespace ExtraChill\CLI\Commands\Artists;
 
+use ExtraChill\CLI\OwnerSiteAbility;
 use WP_CLI;
 use WP_CLI\Utils;
 
@@ -19,70 +20,25 @@ if ( ! defined( 'ABSPATH' ) ) {
 class ArtistCommand {
 
 	/**
-	 * Switch into the artist platform site and ensure its abilities are loaded.
-	 *
-	 * The artist platform abilities (extrachill/artists-list,
-	 * extrachill/get-artist-platform-stats, etc.) are registered by the
-	 * extrachill-artist-platform plugin, which is only active on the artist
-	 * platform subsite. `wp extrachill artists ...` defaults to the network
-	 * main site where that plugin's code never loads, so the abilities are
-	 * absent from the registry and every subcommand fails with
-	 * "ability not available".
-	 *
-	 * switch_to_blog() alone does NOT fix this: it changes the active blog but
-	 * does not load an inactive plugin's PHP. This helper therefore switches to
-	 * the artist platform blog AND requires the plugin's abilities bootstrap,
-	 * then fires its (idempotent-guarded) category + ability registration so
-	 * the abilities resolve in this process.
-	 *
-	 * Each subcommand is a short-lived WP-CLI process, so the switch is left in
-	 * place for the remainder of the command (every subsequent ability execute()
-	 * must also run in the artist site context to read/write its data).
+	 * Require the native Artist Platform WP-CLI bootstrap.
 	 *
 	 * @return void
 	 */
 	private function ensure_artist_site_context() {
-		if ( ! function_exists( 'ec_get_blog_id' ) ) {
-			WP_CLI::error( 'ec_get_blog_id() unavailable — extrachill-multisite must be active to resolve the artist platform site.' );
+		if ( ! function_exists( 'ec_get_blog_id' ) || get_current_blog_id() !== (int) ec_get_blog_id( 'artist' ) ) {
+			$url = function_exists( 'ec_get_site_url' ) ? ec_get_site_url( 'artist' ) : 'https://artist.extrachill.com';
+			WP_CLI::error( sprintf( 'Artist commands must run on the Artist Platform site. Use --url=%s.', $url ) );
 		}
+	}
 
-		$blog_id = ec_get_blog_id( 'artist' );
-		if ( ! $blog_id ) {
-			WP_CLI::error( 'Could not resolve the artist platform site ID.' );
-		}
-
-		if ( get_current_blog_id() !== (int) $blog_id ) {
-			switch_to_blog( $blog_id );
-		}
-
-		// The artist platform plugin only loads on its own subsite, so its
-		// ability registration functions may not be defined here. Load the
-		// abilities bootstrap from the (now active) artist platform site.
-		if ( ! function_exists( 'extrachill_artist_platform_register_abilities' ) ) {
-			if ( ! defined( 'EXTRACHILL_ARTIST_PLATFORM_PLUGIN_DIR' ) ) {
-				define( 'EXTRACHILL_ARTIST_PLATFORM_PLUGIN_DIR', WP_PLUGIN_DIR . '/extrachill-artist-platform/' );
-			}
-
-			$abilities_bootstrap = EXTRACHILL_ARTIST_PLATFORM_PLUGIN_DIR . 'inc/abilities/abilities.php';
-			if ( ! is_readable( $abilities_bootstrap ) ) {
-				WP_CLI::error( 'Artist platform abilities bootstrap not found — is extrachill-artist-platform installed?' );
-			}
-
-			require_once $abilities_bootstrap;
-		}
-
-		// Fire registration directly (idempotent-guarded) rather than re-running
-		// the global wp_abilities_api_* actions, which would re-register every
-		// other plugin's abilities and trigger _doing_it_wrong notices.
-		if ( function_exists( 'extrachill_artist_platform_register_category' ) ) {
-			extrachill_artist_platform_register_category();
-		}
-		if ( function_exists( 'extrachill_artist_platform_register_abilities' )
-			&& function_exists( 'wp_has_ability' )
-			&& ! wp_has_ability( 'extrachill/get-artist-platform-stats' )
-		) {
-			extrachill_artist_platform_register_abilities();
-		}
+	/**
+	 * Resolve an Artist Platform-owned ability from its WP-CLI runtime.
+	 *
+	 * @param string $ability_name Ability name.
+	 * @return \WP_Ability|null Ability instance. Errors when unavailable.
+	 */
+	private function get_artist_ability( $ability_name ) {
+		return OwnerSiteAbility::get( 'artist', 'Artist Platform', $ability_name );
 	}
 
 	/**
@@ -113,7 +69,7 @@ class ArtistCommand {
 	public function count( $args, $assoc_args ) {
 		$this->ensure_artist_site_context();
 
-		$ability = wp_get_ability( 'extrachill/artists-list' );
+		$ability = $this->get_artist_ability( 'extrachill/artists-list' );
 		if ( ! $ability ) {
 			WP_CLI::error( 'extrachill/artists-list ability not available.' );
 		}
@@ -173,7 +129,7 @@ class ArtistCommand {
 
 		$artist_id = absint( $args[0] );
 
-		$ability = wp_get_ability( 'extrachill/get-artist-data' );
+		$ability = $this->get_artist_ability( 'extrachill/get-artist-data' );
 		if ( ! $ability ) {
 			WP_CLI::error( 'extrachill/get-artist-data ability not available.' );
 		}
@@ -254,7 +210,7 @@ class ArtistCommand {
 			$input['user_id'] = absint( $assoc_args['user-id'] );
 		}
 
-		$ability = wp_get_ability( 'extrachill/create-artist' );
+		$ability = $this->get_artist_ability( 'extrachill/create-artist' );
 		if ( ! $ability ) {
 			WP_CLI::error( 'extrachill/create-artist ability not available.' );
 		}
@@ -340,7 +296,7 @@ class ArtistCommand {
 			WP_CLI::error( 'At least one field to update is required.' );
 		}
 
-		$ability = wp_get_ability( 'extrachill/update-artist' );
+		$ability = $this->get_artist_ability( 'extrachill/update-artist' );
 		if ( ! $ability ) {
 			WP_CLI::error( 'extrachill/update-artist ability not available.' );
 		}
@@ -389,7 +345,7 @@ class ArtistCommand {
 
 		$artist_id = absint( $args[0] );
 
-		$ability = wp_get_ability( 'extrachill/get-link-page-data' );
+		$ability = $this->get_artist_ability( 'extrachill/get-link-page-data' );
 		if ( ! $ability ) {
 			WP_CLI::error( 'extrachill/get-link-page-data ability not available.' );
 		}
@@ -446,7 +402,7 @@ class ArtistCommand {
 			WP_CLI::error( 'Second argument must be a valid JSON array of social link objects.' );
 		}
 
-		$ability = wp_get_ability( 'extrachill/save-social-links' );
+		$ability = $this->get_artist_ability( 'extrachill/save-social-links' );
 		if ( ! $ability ) {
 			WP_CLI::error( 'extrachill/save-social-links ability not available.' );
 		}
@@ -499,7 +455,7 @@ class ArtistCommand {
 			WP_CLI::error( 'Second argument must be a valid JSON array of link sections.' );
 		}
 
-		$ability = wp_get_ability( 'extrachill/save-link-page-links' );
+		$ability = $this->get_artist_ability( 'extrachill/save-link-page-links' );
 		if ( ! $ability ) {
 			WP_CLI::error( 'extrachill/save-link-page-links ability not available.' );
 		}
@@ -564,7 +520,7 @@ class ArtistCommand {
 		$section   = absint( $assoc_args['section'] ?? 0 );
 
 		// Read current links.
-		$read_ability = wp_get_ability( 'extrachill/get-link-page-data' );
+		$read_ability = $this->get_artist_ability( 'extrachill/get-link-page-data' );
 		if ( ! $read_ability ) {
 			WP_CLI::error( 'extrachill/get-link-page-data ability not available.' );
 		}
@@ -601,7 +557,7 @@ class ArtistCommand {
 		);
 
 		// Save.
-		$save_ability = wp_get_ability( 'extrachill/save-link-page-links' );
+		$save_ability = $this->get_artist_ability( 'extrachill/save-link-page-links' );
 		if ( ! $save_ability ) {
 			WP_CLI::error( 'extrachill/save-link-page-links ability not available.' );
 		}
@@ -651,7 +607,7 @@ class ArtistCommand {
 		$identifier = $args[1];
 
 		// Read current links.
-		$read_ability = wp_get_ability( 'extrachill/get-link-page-data' );
+		$read_ability = $this->get_artist_ability( 'extrachill/get-link-page-data' );
 		if ( ! $read_ability ) {
 			WP_CLI::error( 'extrachill/get-link-page-data ability not available.' );
 		}
@@ -683,7 +639,7 @@ class ArtistCommand {
 		}
 
 		// Save.
-		$save_ability = wp_get_ability( 'extrachill/save-link-page-links' );
+		$save_ability = $this->get_artist_ability( 'extrachill/save-link-page-links' );
 		if ( ! $save_ability ) {
 			WP_CLI::error( 'extrachill/save-link-page-links ability not available.' );
 		}
@@ -737,7 +693,7 @@ class ArtistCommand {
 		$identifier = $args[1];
 
 		// Read current links.
-		$read_ability = wp_get_ability( 'extrachill/get-link-page-data' );
+		$read_ability = $this->get_artist_ability( 'extrachill/get-link-page-data' );
 		if ( ! $read_ability ) {
 			WP_CLI::error( 'extrachill/get-link-page-data ability not available.' );
 		}
@@ -795,7 +751,7 @@ class ArtistCommand {
 		}
 
 		// Save.
-		$save_ability = wp_get_ability( 'extrachill/save-link-page-links' );
+		$save_ability = $this->get_artist_ability( 'extrachill/save-link-page-links' );
 		if ( ! $save_ability ) {
 			WP_CLI::error( 'extrachill/save-link-page-links ability not available.' );
 		}
@@ -875,7 +831,7 @@ class ArtistCommand {
 
 		// --list mode: show current CSS vars.
 		if ( isset( $assoc_args['list'] ) ) {
-			$read_ability = wp_get_ability( 'extrachill/get-link-page-data' );
+			$read_ability = $this->get_artist_ability( 'extrachill/get-link-page-data' );
 			if ( ! $read_ability ) {
 				WP_CLI::error( 'extrachill/get-link-page-data ability not available.' );
 			}
@@ -933,7 +889,7 @@ class ArtistCommand {
 			WP_CLI::error( 'No style changes specified. Use --list to see current values, or pass flags like --button-bg="#0044cc".' );
 		}
 
-		$ability = wp_get_ability( 'extrachill/save-link-page-styles' );
+		$ability = $this->get_artist_ability( 'extrachill/save-link-page-styles' );
 		if ( ! $ability ) {
 			WP_CLI::error( 'extrachill/save-link-page-styles ability not available.' );
 		}
@@ -984,7 +940,7 @@ class ArtistCommand {
 
 		// --list mode.
 		if ( isset( $assoc_args['list'] ) ) {
-			$read_ability = wp_get_ability( 'extrachill/get-link-page-data' );
+			$read_ability = $this->get_artist_ability( 'extrachill/get-link-page-data' );
 			if ( ! $read_ability ) {
 				WP_CLI::error( 'extrachill/get-link-page-data ability not available.' );
 			}
@@ -1019,7 +975,7 @@ class ArtistCommand {
 			WP_CLI::error( 'No settings specified. Use --list to see current values.' );
 		}
 
-		$ability = wp_get_ability( 'extrachill/save-link-page-settings' );
+		$ability = $this->get_artist_ability( 'extrachill/save-link-page-settings' );
 		if ( ! $ability ) {
 			WP_CLI::error( 'extrachill/save-link-page-settings ability not available.' );
 		}
@@ -1084,7 +1040,7 @@ class ArtistCommand {
 
 		$days = isset( $assoc_args['days'] ) ? max( 0, (int) $assoc_args['days'] ) : 28;
 
-		$ability = wp_get_ability( 'extrachill/get-artist-platform-stats' );
+		$ability = $this->get_artist_ability( 'extrachill/get-artist-platform-stats' );
 		if ( ! $ability ) {
 			WP_CLI::error( 'extrachill/get-artist-platform-stats ability not available.' );
 		}

--- a/inc/Commands/Events/LocationCommand.php
+++ b/inc/Commands/Events/LocationCommand.php
@@ -9,6 +9,7 @@
 
 namespace ExtraChill\CLI\Commands\Events;
 
+use ExtraChill\CLI\OwnerSiteAbility;
 use WP_CLI;
 use WP_CLI\Utils;
 
@@ -19,107 +20,13 @@ if ( ! defined( 'ABSPATH' ) ) {
 class LocationCommand {
 
 	/**
-	 * Switch into the events site and ensure its abilities are loaded.
+	 * Resolve an Events-owned ability from an Events-site WP-CLI runtime.
 	 *
-	 * The events-domain abilities (extrachill/market-report,
-	 * extrachill/audit-event-times, extrachill/fix-event-times,
-	 * extrachill/reconcile-event-locations, extrachill/event-roundup-build)
-	 * are registered by the extrachill-events plugin, which is only active
-	 * on the events subsite. `wp extrachill events ...` defaults to the
-	 * network main site where that plugin's code never loads, so the
-	 * abilities are absent from the registry and every report/ops subcommand
-	 * fails with "ability not available".
-	 *
-	 * switch_to_blog() alone does NOT fix this: it changes the active blog
-	 * but does not load an inactive plugin's PHP. This helper therefore
-	 * switches to the events blog AND requires the plugin's abilities
-	 * bootstrap so the abilities resolve in this process.
-	 *
-	 * The abilities API only accepts registrations while the lazy one-shot
-	 * `wp_abilities_api_init` action is firing (enforced via
-	 * `doing_action()`), and that action fires the first time the registry
-	 * is touched. The events classes register on that action, so the
-	 * bootstrap MUST be loaded before any registry read — otherwise the
-	 * first read fires the action with the events callbacks absent and the
-	 * one-shot is spent. This helper therefore loads + instantiates the
-	 * events ability classes first (queuing their callbacks) and only then
-	 * touches the registry via `wp_has_ability()`, which triggers the action
-	 * during which the events callbacks register. This mirrors
-	 * ArtistCommand::ensure_artist_site_context().
-	 *
-	 * Each subcommand is a short-lived WP-CLI process, so the switch is left
-	 * in place for the remainder of the command (every subsequent ability
-	 * execute() must also run in the events site context to read/write its
-	 * data).
-	 *
-	 * @return void
+	 * @param string $ability_name Ability name.
+	 * @return \WP_Ability|null Ability instance. Errors when unavailable.
 	 */
-	private function ensure_events_site_context() {
-		if ( ! function_exists( 'ec_get_blog_id' ) ) {
-			WP_CLI::error( 'ec_get_blog_id() unavailable — extrachill-multisite must be active to resolve the events site.' );
-		}
-
-		$blog_id = ec_get_blog_id( 'events' );
-		if ( ! $blog_id ) {
-			WP_CLI::error( 'Could not resolve the events site ID.' );
-		}
-
-		if ( get_current_blog_id() !== (int) $blog_id ) {
-			switch_to_blog( $blog_id );
-		}
-
-		// Load the events plugin's abilities bootstrap BEFORE touching the
-		// abilities registry. The bootstrap queues the events category and
-		// ability callbacks on wp_abilities_api_init / its categories
-		// counterpart; the events plugin only loads on its own subsite, so
-		// this code is not defined here yet.
-		if ( ! defined( 'EXTRACHILL_EVENTS_PLUGIN_DIR' ) ) {
-			define( 'EXTRACHILL_EVENTS_PLUGIN_DIR', WP_PLUGIN_DIR . '/extrachill-events/' );
-		}
-
-		$register_bootstrap = EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/abilities/register.php';
-		if ( ! is_readable( $register_bootstrap ) ) {
-			WP_CLI::error( 'Events abilities bootstrap not found — is extrachill-events installed?' );
-		}
-
-		require_once $register_bootstrap;
-
-		// The class-based abilities (location alignment, event times, market
-		// report, roundup) self-register on wp_abilities_api_init from their
-		// constructors. Load and instantiate them so their callbacks are
-		// queued alongside the bootstrap's procedural callbacks.
-		$ability_classes = array(
-			'EventLocationAlignmentAbilities',
-			'EventTimeAuditAbilities',
-			'MarketReportAbilities',
-			'EventRoundupAbilities',
-		);
-
-		foreach ( $ability_classes as $class_base ) {
-			$fqcn = '\ExtraChillEvents\Abilities\\' . $class_base;
-			$file = EXTRACHILL_EVENTS_PLUGIN_DIR . 'inc/Abilities/' . $class_base . '.php';
-
-			if ( ! class_exists( $fqcn ) ) {
-				if ( ! is_readable( $file ) ) {
-					WP_CLI::error( sprintf( 'Events ability class not found: %s', $fqcn ) );
-				}
-				require_once $file;
-			}
-
-			if ( class_exists( $fqcn ) ) {
-				new $fqcn();
-			}
-		}
-
-		// Now that every events callback is queued, touch the registry. This
-		// initializes it (if it hasn't been already) and fires
-		// wp_abilities_api_init, during which the queued events callbacks
-		// register the abilities. On the events site the abilities are
-		// already registered and this is a harmless read. (require_once +
-		// the classes' static $registered guards make repeat calls safe.)
-		if ( function_exists( 'wp_has_ability' ) ) {
-			wp_has_ability( 'extrachill/market-report' );
-		}
+	private function get_events_ability( $ability_name ) {
+		return OwnerSiteAbility::get( 'events', 'Events', $ability_name );
 	}
 
 	/**
@@ -165,7 +72,6 @@ class LocationCommand {
 	 * @when after_wp_load
 	 */
 	public function audit_locations( $args, $assoc_args ) {
-		$this->ensure_events_site_context();
 		$result = $this->run_alignment_ability( $assoc_args, false );
 		$this->render_result( $result, $assoc_args['format'] ?? 'table' );
 	}
@@ -215,12 +121,6 @@ class LocationCommand {
 	 * @when after_wp_load
 	 */
 	public function fix_locations( $args, $assoc_args ) {
-		$this->ensure_events_site_context();
-
-		if ( empty( $assoc_args['yes'] ) ) {
-			WP_CLI::confirm( 'This will update event location terms to match venue city. Continue?' );
-		}
-
 		$result = $this->run_alignment_ability( $assoc_args, true );
 		$this->render_result( $result, $assoc_args['format'] ?? 'table' );
 	}
@@ -233,10 +133,14 @@ class LocationCommand {
 	 * @return array
 	 */
 	private function run_alignment_ability( array $assoc_args, bool $apply ): array {
+		$ability = $this->get_events_ability( 'extrachill/reconcile-event-locations' );
+
+		if ( $apply && empty( $assoc_args['yes'] ) ) {
+			WP_CLI::confirm( 'This will update event location terms to match venue city. Continue?' );
+		}
+
 		// CLI commands run as admin — set current user so ability permission check passes.
 		wp_set_current_user( 1 );
-
-		$ability = wp_get_ability( 'extrachill/reconcile-event-locations' );
 
 		if ( ! $ability ) {
 			WP_CLI::error( 'extrachill/reconcile-event-locations ability not available. Is extrachill-events active?' );
@@ -320,9 +224,7 @@ class LocationCommand {
 	 * @when after_wp_load
 	 */
 	public function market_report( $args, $assoc_args ) {
-		$this->ensure_events_site_context();
-
-		$ability = wp_get_ability( 'extrachill/market-report' );
+		$ability = $this->get_events_ability( 'extrachill/market-report' );
 
 		if ( ! $ability ) {
 			WP_CLI::error( 'extrachill/market-report ability not available. Is extrachill-events active on this site?' );
@@ -448,10 +350,8 @@ class LocationCommand {
 	 * @when after_wp_load
 	 */
 	public function audit_times( $args, $assoc_args ) {
-		$this->ensure_events_site_context();
+		$ability = $this->get_events_ability( 'extrachill/audit-event-times' );
 		wp_set_current_user( 1 );
-
-		$ability = wp_get_ability( 'extrachill/audit-event-times' );
 
 		if ( ! $ability ) {
 			WP_CLI::error( 'extrachill/audit-event-times ability not available. Is extrachill-events active?' );
@@ -554,10 +454,8 @@ class LocationCommand {
 	 * @when after_wp_load
 	 */
 	public function fix_times( $args, $assoc_args ) {
-		$this->ensure_events_site_context();
+		$ability = $this->get_events_ability( 'extrachill/fix-event-times' );
 		wp_set_current_user( 1 );
-
-		$ability = wp_get_ability( 'extrachill/fix-event-times' );
 
 		if ( ! $ability ) {
 			WP_CLI::error( 'extrachill/fix-event-times ability not available. Is extrachill-events active?' );
@@ -771,9 +669,7 @@ class LocationCommand {
 	 * @when after_wp_load
 	 */
 	public function roundup( $args, $assoc_args ) {
-		$this->ensure_events_site_context();
-
-		$ability = wp_get_ability( 'extrachill/event-roundup-build' );
+		$ability = $this->get_events_ability( 'extrachill/event-roundup-build' );
 
 		if ( ! $ability ) {
 			WP_CLI::error( 'extrachill/event-roundup-build ability not available. Is extrachill-events active on this site?' );

--- a/inc/OwnerSiteAbility.php
+++ b/inc/OwnerSiteAbility.php
@@ -1,0 +1,65 @@
+<?php
+/**
+ * Owner-site ability resolution for WP-CLI commands.
+ *
+ * @package ExtraChill\CLI
+ */
+
+namespace ExtraChill\CLI;
+
+use WP_CLI;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+class OwnerSiteAbility {
+
+	/**
+	 * Resolve an ability from its normally bootstrapped owner site.
+	 *
+	 * @param string $site_key     Network site key.
+	 * @param string $site_label   Human-readable owner label.
+	 * @param string $ability_name Ability name.
+	 * @return \WP_Ability|null Ability instance. Errors when unavailable.
+	 */
+	public static function get( $site_key, $site_label, $ability_name ) {
+		if ( ! function_exists( 'ec_get_blog_id' ) ) {
+			WP_CLI::error( 'Extra Chill Network site resolution is unavailable. Ensure the Network plugin is active.' );
+		}
+
+		$owner_blog_id = (int) ec_get_blog_id( $site_key );
+		if ( ! $owner_blog_id ) {
+			WP_CLI::error( sprintf( 'Could not resolve the %s owner site.', $site_label ) );
+		}
+
+		$owner_url = function_exists( 'ec_get_site_url' ) ? ec_get_site_url( $site_key ) : get_home_url( $owner_blog_id );
+		if ( get_current_blog_id() !== $owner_blog_id ) {
+			WP_CLI::error(
+				sprintf(
+					'%1$s is owned by the %2$s site. Run this command with --url=%3$s.',
+					$ability_name,
+					$site_label,
+					$owner_url
+				)
+			);
+		}
+
+		if ( ! function_exists( 'wp_get_ability' ) ) {
+			WP_CLI::error( 'Abilities API not available (requires WordPress 6.9+).' );
+		}
+
+		$ability = wp_get_ability( $ability_name );
+		if ( ! $ability ) {
+			$message = sprintf(
+				'%1$s ability not available on %2$s. Ensure its owner plugin is active for %3$s.',
+				$ability_name,
+				$site_label,
+				$owner_url
+			);
+			WP_CLI::error( $message );
+		}
+
+		return $ability;
+	}
+}

--- a/tests/OwnerSiteAbilityTest.php
+++ b/tests/OwnerSiteAbilityTest.php
@@ -1,0 +1,114 @@
+<?php
+/**
+ * Contract tests for owner-site ability resolution.
+ */
+
+namespace {
+	define( 'ABSPATH', __DIR__ . '/' );
+
+	class OwnerSiteAbilityTestError extends \RuntimeException {}
+
+	class WP_CLI {
+		public static function error( $message ) {
+			throw new OwnerSiteAbilityTestError( $message );
+		}
+	}
+
+	$owner_site_current_blog_id = 7;
+	$owner_site_registry_ready  = false;
+	$owner_site_registry_inits  = 0;
+	$owner_site_registry_reads  = 0;
+	$owner_site_abilities       = array(
+		'extrachill/market-report'               => (object) array( 'name' => 'market-report' ),
+		'extrachill/reconcile-event-locations'   => (object) array( 'name' => 'reconcile-event-locations' ),
+	);
+
+	function ec_get_blog_id( $site_key ) {
+		return array(
+			'events' => 7,
+			'artist' => 4,
+		)[ $site_key ] ?? 0;
+	}
+
+	function ec_get_site_url( $site_key ) {
+		return 'https://' . $site_key . '.extrachill.com';
+	}
+
+	function get_current_blog_id() {
+		global $owner_site_current_blog_id;
+		return $owner_site_current_blog_id;
+	}
+
+	function get_home_url( $blog_id ) {
+		return 'https://site-' . $blog_id . '.example.com';
+	}
+
+	function wp_get_ability( $name ) {
+		global $owner_site_abilities, $owner_site_registry_inits, $owner_site_registry_reads, $owner_site_registry_ready;
+
+		++$owner_site_registry_reads;
+		if ( ! $owner_site_registry_ready ) {
+			$owner_site_registry_ready = true;
+			++$owner_site_registry_inits;
+		}
+
+		return $owner_site_abilities[ $name ] ?? null;
+	}
+
+	function owner_site_assert_same( $expected, $actual, $message ) {
+		if ( $expected !== $actual ) {
+			throw new \RuntimeException( $message . '\nExpected: ' . var_export( $expected, true ) . '\nActual: ' . var_export( $actual, true ) );
+		}
+	}
+
+	function owner_site_assert_contains( $needle, $haystack, $message ) {
+		if ( false === strpos( $haystack, $needle ) ) {
+			throw new \RuntimeException( $message . '\nMissing: ' . $needle . '\nActual: ' . $haystack );
+		}
+	}
+
+	require_once dirname( __DIR__ ) . '/inc/OwnerSiteAbility.php';
+
+	use ExtraChill\CLI\OwnerSiteAbility;
+
+	// The first lookup may initialize the lazy registry after owner callbacks are composed.
+	$ability = OwnerSiteAbility::get( 'events', 'Events', 'extrachill/market-report' );
+	owner_site_assert_same( 'market-report', $ability->name, 'Correct owner-site lookup must return the registered ability.' );
+	owner_site_assert_same( 1, $owner_site_registry_inits, 'The first lookup must initialize the registry exactly once.' );
+
+	// A lookup after another ability initialized the registry must remain a read only operation.
+	$ability = OwnerSiteAbility::get( 'events', 'Events', 'extrachill/reconcile-event-locations' );
+	owner_site_assert_same( 'reconcile-event-locations', $ability->name, 'Lookup after registry initialization must succeed.' );
+	OwnerSiteAbility::get( 'events', 'Events', 'extrachill/market-report' );
+	owner_site_assert_same( 1, $owner_site_registry_inits, 'Repeated lookups must not initialize or register abilities again.' );
+	owner_site_assert_same( 3, $owner_site_registry_reads, 'Each resolution must perform only its public registry read.' );
+
+	$owner_site_current_blog_id = 1;
+	try {
+		OwnerSiteAbility::get( 'events', 'Events', 'extrachill/market-report' );
+		throw new \RuntimeException( 'Wrong-site lookup should fail.' );
+	} catch ( OwnerSiteAbilityTestError $error ) {
+		owner_site_assert_contains( '--url=https://events.extrachill.com', $error->getMessage(), 'Wrong-site errors must provide the owner URL.' );
+	}
+	owner_site_assert_same( 3, $owner_site_registry_reads, 'Wrong-site resolution must not touch the ability registry.' );
+
+	$owner_site_current_blog_id = 4;
+	try {
+		OwnerSiteAbility::get( 'artist', 'Artist Platform', 'extrachill/missing-owner-ability' );
+		throw new \RuntimeException( 'Missing owner ability should fail.' );
+	} catch ( OwnerSiteAbilityTestError $error ) {
+		owner_site_assert_contains( 'Ensure its owner plugin is active', $error->getMessage(), 'Missing-owner errors must explain how to restore composition.' );
+		owner_site_assert_contains( 'https://artist.extrachill.com', $error->getMessage(), 'Missing-owner errors must identify the owner URL.' );
+	}
+
+	$events_source = file_get_contents( dirname( __DIR__ ) . '/inc/Commands/Events/LocationCommand.php' );
+	$artist_source = file_get_contents( dirname( __DIR__ ) . '/inc/Commands/Artists/ArtistCommand.php' );
+	$source        = $events_source . $artist_source;
+	owner_site_assert_same( false, strpos( $source, 'WP_PLUGIN_DIR' ), 'Commands must not define sibling plugin paths.' );
+	owner_site_assert_same( false, strpos( $source, 'require_once' ), 'Commands must not require sibling plugin files.' );
+	owner_site_assert_same( false, strpos( $source, 'ExtraChillEvents\\Abilities' ), 'Commands must not name sibling ability classes.' );
+	owner_site_assert_same( false, strpos( $source, 'extrachill_artist_platform_register_abilities' ), 'Commands must not call sibling registration functions.' );
+	owner_site_assert_same( false, strpos( $source, 'switch_to_blog' ), 'Commands must use native owner-site bootstrap instead of switching database context.' );
+
+	echo "OwnerSiteAbilityTest passed\n";
+}


### PR DESCRIPTION
## Summary
- stop Events and Artist commands from requiring or instantiating sibling plugin internals
- require native owner-site `--url` composition and return actionable wrong-site or inactive-owner errors
- cover lazy/already-initialized registry access, owner context, missing owner abilities, and duplicate-registration boundaries

## Verification
- all 15 standalone PHP contract suites pass
- PHPCS and PHPStan level 7 pass for the new resolver and contract test
- Homeboy architecture audit reports no introduced findings
- live owner-site and wrong-site command smoke checks pass
- managed WordPress test discovery is blocked by the known missing WP Codebox CLI artifact (Extra-Chill/homeboy#11713, #11591)
- whole-file lint continues to report pre-existing findings in the legacy Artist and Events command files; new files pass cleanly

Closes #130