### PR TITLE
fix: scope platform queue health to bootstrap site

### DIFF
--- a/homeboy.json
+++ b/homeboy.json
@@ -17,6 +17,7 @@
       "php tests/OutboundCommandTest.php",
       "php tests/ConversionCommandTest.php",
       "php tests/RouteTransitionsCommandTest.php",
+      "php tests/HealthCommandTest.php",
       "php tests/SummaryCommandTest.php",
       "php tests/RetentionCommandTest.php",
       "php tests/UserLocalSceneCommandTest.php",

--- a/inc/Commands/Platform/HealthCommand.php
+++ b/inc/Commands/Platform/HealthCommand.php
@@ -105,40 +105,42 @@ class HealthCommand {
 			'jobs'       => function_exists( 'wp_get_ability' ) ? wp_get_ability( 'datamachine/get-jobs-summary' ) : null,
 		);
 
-		// Network-global signals come from host-wide / network-scoped sources
-		// (a single debug.log, a single network-scoped jobs table). They are
-		// computed ONCE so the scorecard never implies false per-site
-		// granularity by repeating identical numbers on every row.
+		// The error log is host-wide. Queue storage is site-owned, and the jobs
+		// ability is bound to the bootstrap site's $wpdb->prefix when WordPress
+		// loads. Switching blogs here would not rebind its repositories.
 		$network = array(
 			'errors_per_day' => $this->compose_errors( $abilities['errors'], $days ),
-			'queue_failed'   => $this->compose_queue( $abilities['jobs'], 'failed' ),
-			'queue_stuck'    => $this->compose_queue( $abilities['jobs'], 'stuck' ),
+		);
+		$queue   = array(
+			'blog_id' => get_current_blog_id(),
+			'failed'  => $this->compose_queue( $abilities['jobs'], 'failed' ),
+			'stuck'   => $this->compose_queue( $abilities['jobs'], 'stuck' ),
 		);
 
 		$records = array();
 		foreach ( $this->get_network_sites() as $blog_id => $hostname ) {
-			$records[] = $this->compose_site( $blog_id, $hostname, $days, $abilities );
+			$record                 = $this->compose_site( $blog_id, $hostname, $days, $abilities );
+			$record['queue_failed'] = $queue['blog_id'] === $blog_id ? $queue['failed'] : self::GAP;
+			$record['queue_stuck']  = $queue['blog_id'] === $blog_id ? $queue['stuck'] : self::GAP;
+			$records[]              = $record;
 		}
 
 		if ( 'table' !== $format ) {
-			// In machine-readable output, attach the network-global signals to
-			// every record so each row is self-describing for piping/jq, while
-			// keeping their network-scoped meaning explicit via the key name.
+			// Keep the host-wide error signal explicit while queue fields remain
+			// attached only to the site context that the ability actually read.
 			$rows = array();
 			foreach ( $records as $r ) {
 				$rows[] = array_merge(
 					$r,
 					array(
 						'network_errors_per_day' => $network['errors_per_day'],
-						'network_queue_failed'   => $network['queue_failed'],
-						'network_queue_stuck'    => $network['queue_stuck'],
 					)
 				);
 			}
 			Utils\format_items(
 				$format,
 				$rows,
-				array( 'site', 'blog_id', 'sessions', 'organic_pct', 'direct_pct', 'return_rate', 'search_gaps', 'content', 'network_errors_per_day', 'network_queue_failed', 'network_queue_stuck' )
+				array( 'site', 'blog_id', 'sessions', 'organic_pct', 'direct_pct', 'return_rate', 'search_gaps', 'content', 'network_errors_per_day', 'queue_failed', 'queue_stuck' )
 			);
 			return;
 		}
@@ -356,9 +358,8 @@ class HealthCommand {
 	/**
 	 * Compose a queue-health metric from datamachine/get-jobs-summary.
 	 *
-	 * Data Machine jobs live in a single network-scoped table (under the base
-	 * prefix), so this is a network-global signal — independent of blog
-	 * context and computed once for the whole platform.
+	 * Data Machine jobs use the current site's table prefix. The resolved
+	 * ability reads only the site used to bootstrap this WP-CLI process.
 	 *
 	 * @param \WP_Ability|null $ability Jobs-summary ability (or null if absent).
 	 * @param string      $metric  Either 'failed' or 'stuck'.
@@ -458,11 +459,10 @@ class HealthCommand {
 		}
 		WP_CLI::log( '' );
 
-		// Network-global signals (host-wide error log + network-scoped jobs
-		// table) are reported once, not faked into per-site granularity.
+		// The host-wide error signal is reported once. Queue health is rendered
+		// below only for the site whose context bootstrapped the jobs ability.
 		WP_CLI::log( 'Network-wide' );
 		WP_CLI::log( sprintf( '    Errors/day:  %s', $this->fmt( $network['errors_per_day'] ) ) );
-		WP_CLI::log( sprintf( '    Queue:       %s failed   %s stuck', $this->fmt( $network['queue_failed'] ), $this->fmt( $network['queue_stuck'] ) ) );
 		WP_CLI::log( '' );
 		WP_CLI::log( 'Per-surface' );
 		WP_CLI::log( str_repeat( '─', 72 ) );
@@ -473,6 +473,7 @@ class HealthCommand {
 			WP_CLI::log( sprintf( '    Return rate: %s', $this->pct( $r['return_rate'] ) ) );
 			WP_CLI::log( sprintf( '    Search gaps: %s', $this->fmt( $r['search_gaps'] ) ) );
 			WP_CLI::log( sprintf( '    Content:     %s', $r['content'] ) );
+			WP_CLI::log( sprintf( '    Queue:       %s failed   %s stuck', $this->fmt( $r['queue_failed'] ), $this->fmt( $r['queue_stuck'] ) ) );
 			WP_CLI::log( '' );
 		}
 

--- a/tests/HealthCommandTest.php
+++ b/tests/HealthCommandTest.php
@@ -1,0 +1,131 @@
+<?php
+/**
+ * Multisite ownership tests for the platform health queue scorecard.
+ */
+
+namespace {
+	define( 'ABSPATH', __DIR__ . '/' );
+
+	class WP_CLI {
+		public static $messages = array();
+
+		public static function log( $message ) {
+			self::$messages[] = $message;
+		}
+	}
+
+	class HealthCommandTestAbility {
+		public $result = array();
+
+		public function execute( $input ) {
+			return $this->result;
+		}
+	}
+
+	$health_command_current_blog = 1;
+	$health_command_blog_stack   = array();
+	$health_command_jobs_ability = new HealthCommandTestAbility();
+
+	function wp_get_ability( $name ) {
+		global $health_command_jobs_ability;
+		return 'datamachine/get-jobs-summary' === $name ? $health_command_jobs_ability : null;
+	}
+
+	function get_current_blog_id() {
+		global $health_command_current_blog;
+		return $health_command_current_blog;
+	}
+
+	function switch_to_blog( $blog_id ) {
+		global $health_command_blog_stack, $health_command_current_blog;
+		$health_command_blog_stack[] = $health_command_current_blog;
+		$health_command_current_blog = $blog_id;
+		return true;
+	}
+
+	function restore_current_blog() {
+		global $health_command_blog_stack, $health_command_current_blog;
+		$health_command_current_blog = array_pop( $health_command_blog_stack );
+		return true;
+	}
+
+	function get_sites( $args ) {
+		return array( 1, 7 );
+	}
+
+	function get_blog_details( $blog_id ) {
+		return (object) array(
+			'domain' => 1 === (int) $blog_id ? 'extrachill.com' : 'events.extrachill.com',
+		);
+	}
+
+	function get_post_types( $args, $output ) {
+		return array();
+	}
+
+	function wp_count_posts( $type ) {
+		return (object) array();
+	}
+
+	function is_wp_error( $value ) {
+		return false;
+	}
+
+	function health_command_assert_same( $expected, $actual, $message ) {
+		if ( $expected !== $actual ) {
+			throw new \RuntimeException( $message . '\nExpected: ' . var_export( $expected, true ) . '\nActual: ' . var_export( $actual, true ) );
+		}
+	}
+}
+
+namespace WP_CLI\Utils {
+	$health_command_formats = array();
+
+	function format_items( $format, $items, $fields ) {
+		global $health_command_formats;
+		$health_command_formats[] = compact( 'format', 'items', 'fields' );
+	}
+}
+
+namespace {
+	require_once dirname( __DIR__ ) . '/inc/Commands/Platform/HealthCommand.php';
+
+	use ExtraChill\CLI\Commands\Platform\HealthCommand;
+
+	global $health_command_current_blog, $health_command_formats, $health_command_jobs_ability;
+
+	$command = new HealthCommand();
+
+	// A clean main-site ability result must not be repeated as a false network total.
+	$health_command_jobs_ability->result = array(
+		'summary' => array(
+			'failed_count'           => 0,
+			'stuck_processing_count' => 0,
+		),
+	);
+	$command->health( array(), array( 'format' => 'json' ) );
+	$main_rows = $health_command_formats[0]['items'];
+	health_command_assert_same( 0, $main_rows[0]['queue_failed'], 'The bootstrap site must receive its own failed count.' );
+	health_command_assert_same( 0, $main_rows[0]['queue_stuck'], 'The bootstrap site must receive its own stuck count.' );
+	health_command_assert_same( HealthCommand::GAP, $main_rows[1]['queue_failed'], 'A subsite must not inherit the main-site failed count.' );
+	health_command_assert_same( HealthCommand::GAP, $main_rows[1]['queue_stuck'], 'A subsite must not inherit the main-site stuck count.' );
+	health_command_assert_same( false, array_key_exists( 'network_queue_failed', $main_rows[0] ), 'Machine output must not claim the site-owned count is network-wide.' );
+	health_command_assert_same( false, array_key_exists( 'network_queue_stuck', $main_rows[0] ), 'Machine output must not claim the site-owned count is network-wide.' );
+
+	// Bootstrapping the Events site exposes its site-owned queue on the Events row.
+	$health_command_current_blog = 7;
+	$health_command_jobs_ability->result = array(
+		'summary' => array(
+			'failed_count'           => 5681,
+			'stuck_processing_count' => 80,
+		),
+	);
+	$command->health( array(), array( 'format' => 'json' ) );
+	$events_rows = $health_command_formats[1]['items'];
+	health_command_assert_same( HealthCommand::GAP, $events_rows[0]['queue_failed'], 'The main-site row must remain uninstrumented in an Events bootstrap.' );
+	health_command_assert_same( HealthCommand::GAP, $events_rows[0]['queue_stuck'], 'The main-site row must remain uninstrumented in an Events bootstrap.' );
+	health_command_assert_same( 5681, $events_rows[1]['queue_failed'], 'The Events row must expose its failed jobs.' );
+	health_command_assert_same( 80, $events_rows[1]['queue_stuck'], 'The Events row must expose its stuck processing jobs.' );
+
+	echo "HealthCommandTest passed\n";
+}


### PR DESCRIPTION
## Summary
- stop labeling and repeating a site-owned Data Machine queue summary as a network-wide total
- attach queue counts only to the site that bootstrapped the WP-CLI process and mark other site rows as `not instrumented`
- add multisite coverage for a clean main-site queue and an unhealthy Events-site queue

## Root cause
`HealthCommand` resolved `datamachine/get-jobs-summary` once before iterating network sites, based on the incorrect assumption that Data Machine jobs use a base-prefix network table. Data Machine's `Jobs` repository inherits `BaseRepository`, whose default table prefix is `$wpdb->prefix`; the jobs ability constructs that repository during WordPress bootstrap.

The old scorecard was false-green because a summary from the bootstrap site's job table was labeled `network_queue_failed` / `network_queue_stuck` and duplicated onto every machine-readable site row. A clean main site therefore appeared to prove every subsite queue was clean.

## Multisite ownership and context
The jobs summary ability has no `blog_id` input and is bound to the site selected by WP-CLI's native `--url` bootstrap. Calling `switch_to_blog()` after the ability has been registered does not reconstruct its repository or change the already-bound table name, so the CLI cannot correctly aggregate all site-owned queues in one process without an owner-layer primitive.

This change intentionally takes the issue's relabeling path rather than recreating Data Machine queue logic or shelling around the owner API. `queue_failed` and `queue_stuck` now appear only on the row matching `get_current_blog_id()`; all other rows are explicitly `not instrumented`. Host-wide error counts remain `network_errors_per_day`. To inspect Events queue health, bootstrap Events with `--url=https://events.extrachill.com`.

## Tests
Added `tests/HealthCommandTest.php` and registered it in Homeboy self-checks. It verifies:
- main-site zeroes do not propagate to the Events row
- `network_queue_failed` and `network_queue_stuck` are removed
- an Events bootstrap reports `5681` failed and `80` stuck only on the Events row

Commands run:
- `php tests/HealthCommandTest.php` - passed
- all 16 commands in `homeboy.json` `self_checks.test` - passed
- `php -l inc/Commands/Platform/HealthCommand.php` - passed
- `php -l tests/HealthCommandTest.php` - passed
- `git diff --check` - passed

## Production verification plan
After a separately approved release and deployment:
1. Run `wp --path=/var/www/extrachill.com --url=https://extrachill.com extrachill platform health --days=28 --format=json` and confirm only the main-site row has numeric `queue_failed` / `queue_stuck` values.
2. Run the same command with `--url=https://events.extrachill.com` and confirm only the Events row has numeric queue values reflecting the Events-owned jobs table.
3. Confirm no row contains `network_queue_failed` or `network_queue_stuck`, and `network_errors_per_day` remains network-scoped.
4. Compare the Events row with the read-only canonical `wp --url=https://events.extrachill.com datamachine jobs summary --format=json` output. Do not run recovery or cleanup.

Closes #124