### PR TITLE
fix: read live queue summary shape

### DIFF
--- a/inc/Commands/Platform/HealthCommand.php
+++ b/inc/Commands/Platform/HealthCommand.php
@@ -372,17 +372,21 @@ class HealthCommand {
 
 		$result = $ability->execute( array() );
 
-		if ( is_wp_error( $result ) || empty( $result['summary'] ) ) {
-			return 0;
+		if (
+			is_wp_error( $result )
+			|| ! is_array( $result )
+			|| ! isset( $result['failed_count'], $result['stuck_processing_count'] )
+			|| ! is_int( $result['failed_count'] )
+			|| ! is_int( $result['stuck_processing_count'] )
+		) {
+			return self::GAP;
 		}
-
-		$summary = $result['summary'];
 
 		if ( 'stuck' === $metric ) {
-			return (int) ( $summary['stuck_processing_count'] ?? 0 );
+			return $result['stuck_processing_count'];
 		}
 
-		return (int) ( $summary['failed_count'] ?? 0 );
+		return $result['failed_count'];
 	}
 
 	/**

--- a/tests/HealthCommandTest.php
+++ b/tests/HealthCommandTest.php
@@ -14,6 +14,8 @@ namespace {
 		}
 	}
 
+	class WP_Error {}
+
 	class HealthCommandTestAbility {
 		public $result = array();
 
@@ -68,7 +70,7 @@ namespace {
 	}
 
 	function is_wp_error( $value ) {
-		return false;
+		return $value instanceof WP_Error;
 	}
 
 	function health_command_assert_same( $expected, $actual, $message ) {
@@ -98,10 +100,8 @@ namespace {
 
 	// A clean main-site ability result must not be repeated as a false network total.
 	$health_command_jobs_ability->result = array(
-		'summary' => array(
-			'failed_count'           => 0,
-			'stuck_processing_count' => 0,
-		),
+		'failed_count'           => 0,
+		'stuck_processing_count' => 0,
 	);
 	$command->health( array(), array( 'format' => 'json' ) );
 	$main_rows = $health_command_formats[0]['items'];
@@ -115,17 +115,28 @@ namespace {
 	// Bootstrapping the Events site exposes its site-owned queue on the Events row.
 	$health_command_current_blog = 7;
 	$health_command_jobs_ability->result = array(
-		'summary' => array(
-			'failed_count'           => 5681,
-			'stuck_processing_count' => 80,
-		),
+		'failed_count'           => 1027,
+		'stuck_processing_count' => 626,
 	);
 	$command->health( array(), array( 'format' => 'json' ) );
 	$events_rows = $health_command_formats[1]['items'];
 	health_command_assert_same( HealthCommand::GAP, $events_rows[0]['queue_failed'], 'The main-site row must remain uninstrumented in an Events bootstrap.' );
 	health_command_assert_same( HealthCommand::GAP, $events_rows[0]['queue_stuck'], 'The main-site row must remain uninstrumented in an Events bootstrap.' );
-	health_command_assert_same( 5681, $events_rows[1]['queue_failed'], 'The Events row must expose its failed jobs.' );
-	health_command_assert_same( 80, $events_rows[1]['queue_stuck'], 'The Events row must expose its stuck processing jobs.' );
+	health_command_assert_same( 1027, $events_rows[1]['queue_failed'], 'The Events row must expose its failed jobs.' );
+	health_command_assert_same( 626, $events_rows[1]['queue_stuck'], 'The Events row must expose its stuck processing jobs.' );
+
+	// A partial or malformed owner payload must remain visibly uninstrumented.
+	$health_command_jobs_ability->result = array( 'failed_count' => 0 );
+	$command->health( array(), array( 'format' => 'json' ) );
+	$malformed_rows = $health_command_formats[2]['items'];
+	health_command_assert_same( HealthCommand::GAP, $malformed_rows[1]['queue_failed'], 'A partial payload must not become a healthy failed count.' );
+	health_command_assert_same( HealthCommand::GAP, $malformed_rows[1]['queue_stuck'], 'A partial payload must not become a healthy stuck count.' );
+
+	$health_command_jobs_ability->result = new WP_Error();
+	$command->health( array(), array( 'format' => 'json' ) );
+	$error_rows = $health_command_formats[3]['items'];
+	health_command_assert_same( HealthCommand::GAP, $error_rows[1]['queue_failed'], 'An owner error must not become a healthy failed count.' );
+	health_command_assert_same( HealthCommand::GAP, $error_rows[1]['queue_stuck'], 'An owner error must not become a healthy stuck count.' );
 
 	echo "HealthCommandTest passed\n";
 }


### PR DESCRIPTION
## Summary

- read `failed_count` and `stuck_processing_count` from the live top-level jobs-summary ability payload
- return the existing scorecard gap sentinel when the ability errors or either counter is missing or malformed
- update multisite regression coverage with the observed Events values and malformed/error payload cases

## Root cause

`HealthCommand::compose_queue()` required a nested `$result['summary']` payload, while the live owner output consumed by the Events-context command exposes both queue counters at the top level. The fallback returned integer zero, turning a contract mismatch or ability error into a false healthy scorecard.

## Behavior change

The bootstrap site's queue fields now preserve top-level integer counters exactly. A `WP_Error`, non-array result, missing counter, or non-integer counter yields `HealthCommand::GAP` for both queue metrics rather than zero. Queue ownership and bootstrap-site scoping remain unchanged.

## Tests

- `php tests/HealthCommandTest.php`
- all 16 standalone PHP test commands declared in `homeboy.json`
- `php -l inc/Commands/Platform/HealthCommand.php`
- `php -l tests/HealthCommandTest.php`
- Homeboy audit: passed with zero findings
- Homeboy lint: PHPCS, ESLint, and PHPStan level 7 passed with zero findings

Homeboy's PHPUnit-oriented test wrapper reported zero executed tests because this repository uses standalone PHP scripts; every configured script was therefore run directly and passed.

## Production verification

After a separately approved release and deploy, compare the Events row and owner summary without mutating jobs:

```bash
wp --path=/var/www/extrachill.com --url=https://events.extrachill.com extrachill platform health --days=28 --format=json
wp --path=/var/www/extrachill.com --url=https://events.extrachill.com --user=1 datamachine jobs summary --format=json
```

Confirm the Events row's `queue_failed` equals top-level `failed_count` and `queue_stuck` equals top-level `stuck_processing_count`.

Closes #134