### PR TITLE
fix: scope platform health errors to network

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,21 @@ wp plugin activate extrachill-cli --network --allow-root
 
 ## Commands
 
+### Platform Health
+
+The platform health command keeps host-wide and site-owned signals in distinct
+machine-readable scopes. JSON returns a `network` object and a `sites` array.
+CSV returns one row with `scope=network`, followed by `scope=site` rows; the
+`network_errors_per_day` cell is populated only on the network row.
+
+```bash
+wp extrachill platform health --format=json
+wp extrachill platform health --format=csv
+```
+
+This scoped contract intentionally replaces the older JSON/CSV shape that
+repeated the host-wide error rate on every site record.
+
 ### Multisite Owner Context
 
 Commands backed by site-only abilities must use WP-CLI's native `--url` bootstrap

--- a/inc/Commands/Platform/HealthCommand.php
+++ b/inc/Commands/Platform/HealthCommand.php
@@ -63,8 +63,9 @@ class HealthCommand {
 	 * ---
 	 *
 	 * [--format=<format>]
-	 * : Output format. The "table" format prints a compact per-site block;
-	 *   "json" / "csv" emit one structured record per site.
+	 * : Output format. The "table" format prints a compact per-site block.
+	 *   JSON returns separate "network" and "sites" scopes. CSV emits an
+	 *   explicit network row followed by site rows.
 	 * ---
 	 * default: table
 	 * options:
@@ -125,27 +126,66 @@ class HealthCommand {
 			$records[]              = $record;
 		}
 
-		if ( 'table' !== $format ) {
-			// Keep the host-wide error signal explicit while queue fields remain
-			// attached only to the site context that the ability actually read.
-			$rows = array();
-			foreach ( $records as $r ) {
-				$rows[] = array_merge(
-					$r,
-					array(
-						'network_errors_per_day' => $network['errors_per_day'],
-					)
-				);
-			}
+		if ( 'json' === $format ) {
+			WP_CLI::print_value(
+				array(
+					'network' => $network,
+					'sites'   => $records,
+				),
+				array( 'format' => 'json' )
+			);
+			return;
+		}
+
+		if ( 'csv' === $format ) {
 			Utils\format_items(
 				$format,
-				$rows,
-				array( 'site', 'blog_id', 'sessions', 'organic_pct', 'direct_pct', 'return_rate', 'search_gaps', 'content', 'network_errors_per_day', 'queue_failed', 'queue_stuck' )
+				$this->csv_rows( $records, $network ),
+				array( 'scope', 'site', 'blog_id', 'sessions', 'organic_pct', 'direct_pct', 'return_rate', 'search_gaps', 'content', 'network_errors_per_day', 'queue_failed', 'queue_stuck' )
 			);
 			return;
 		}
 
 		$this->render_table( $records, $network, $days, $abilities );
+	}
+
+	/**
+	 * Build flat CSV rows without assigning network signals to a site.
+	 *
+	 * @param array<int, array<string, mixed>> $records Per-site records.
+	 * @param array<string, mixed>             $network Network-global signals.
+	 * @return array<int, array<string, mixed>>
+	 */
+	private function csv_rows( array $records, array $network ) {
+		$empty_site = array(
+			'site'         => '',
+			'blog_id'      => '',
+			'sessions'     => '',
+			'organic_pct'  => '',
+			'direct_pct'   => '',
+			'return_rate'  => '',
+			'search_gaps'  => '',
+			'content'      => '',
+			'queue_failed' => '',
+			'queue_stuck'  => '',
+		);
+		$rows       = array(
+			array_merge(
+				array( 'scope' => 'network' ),
+				$empty_site,
+				array( 'network_errors_per_day' => $network['errors_per_day'] )
+			),
+		);
+
+		foreach ( $records as $record ) {
+			$rows[] = array_merge(
+				array( 'scope' => 'site' ),
+				$record,
+				array( 'network_errors_per_day' => '' )
+			);
+		}
+
+		return $rows;
 	}
 
 	/**

--- a/tests/HealthCommandTest.php
+++ b/tests/HealthCommandTest.php
@@ -8,9 +8,14 @@ namespace {
 
 	class WP_CLI {
 		public static $messages = array();
+		public static $printed  = array();
 
 		public static function log( $message ) {
 			self::$messages[] = $message;
+		}
+
+		public static function print_value( $value, $args ) {
+			self::$printed[] = compact( 'value', 'args' );
 		}
 	}
 
@@ -24,13 +29,20 @@ namespace {
 		}
 	}
 
-	$health_command_current_blog = 1;
-	$health_command_blog_stack   = array();
-	$health_command_jobs_ability = new HealthCommandTestAbility();
+	$health_command_current_blog  = 1;
+	$health_command_blog_stack    = array();
+	$health_command_jobs_ability  = new HealthCommandTestAbility();
+	$health_command_error_ability = new HealthCommandTestAbility();
 
 	function wp_get_ability( $name ) {
-		global $health_command_jobs_ability;
-		return 'datamachine/get-jobs-summary' === $name ? $health_command_jobs_ability : null;
+		global $health_command_error_ability, $health_command_jobs_ability;
+		if ( 'datamachine/get-jobs-summary' === $name ) {
+			return $health_command_jobs_ability;
+		}
+		if ( 'extrachill/get-php-error-summary' === $name ) {
+			return $health_command_error_ability;
+		}
+		return null;
 	}
 
 	function get_current_blog_id() {
@@ -78,6 +90,12 @@ namespace {
 			throw new \RuntimeException( $message . '\nExpected: ' . var_export( $expected, true ) . '\nActual: ' . var_export( $actual, true ) );
 		}
 	}
+
+	function health_command_assert_contains( $needle, $haystack, $message ) {
+		if ( false === strpos( $haystack, $needle ) ) {
+			throw new \RuntimeException( $message . '\nMissing: ' . $needle . '\nActual: ' . $haystack );
+		}
+	}
 }
 
 namespace WP_CLI\Utils {
@@ -94,23 +112,27 @@ namespace {
 
 	use ExtraChill\CLI\Commands\Platform\HealthCommand;
 
-	global $health_command_current_blog, $health_command_formats, $health_command_jobs_ability;
+	global $health_command_current_blog, $health_command_error_ability, $health_command_formats, $health_command_jobs_ability;
 
 	$command = new HealthCommand();
+	$health_command_error_ability->result = array( 'active_per_day' => 42.5 );
 
-	// A clean main-site ability result must not be repeated as a false network total.
+	// JSON must preserve network and site scopes as distinct typed structures.
 	$health_command_jobs_ability->result = array(
 		'failed_count'           => 0,
 		'stuck_processing_count' => 0,
 	);
 	$command->health( array(), array( 'format' => 'json' ) );
-	$main_rows = $health_command_formats[0]['items'];
+	$main_json = WP_CLI::$printed[0]['value'];
+	$main_rows = $main_json['sites'];
+	health_command_assert_same( array( 'errors_per_day' => 42.5 ), $main_json['network'], 'JSON must expose the host-wide error rate exactly once in its network scope.' );
+	health_command_assert_same( array( 'format' => 'json' ), WP_CLI::$printed[0]['args'], 'JSON must use WP-CLI structured output.' );
 	health_command_assert_same( 0, $main_rows[0]['queue_failed'], 'The bootstrap site must receive its own failed count.' );
 	health_command_assert_same( 0, $main_rows[0]['queue_stuck'], 'The bootstrap site must receive its own stuck count.' );
 	health_command_assert_same( HealthCommand::GAP, $main_rows[1]['queue_failed'], 'A subsite must not inherit the main-site failed count.' );
 	health_command_assert_same( HealthCommand::GAP, $main_rows[1]['queue_stuck'], 'A subsite must not inherit the main-site stuck count.' );
-	health_command_assert_same( false, array_key_exists( 'network_queue_failed', $main_rows[0] ), 'Machine output must not claim the site-owned count is network-wide.' );
-	health_command_assert_same( false, array_key_exists( 'network_queue_stuck', $main_rows[0] ), 'Machine output must not claim the site-owned count is network-wide.' );
+	health_command_assert_same( false, array_key_exists( 'network_errors_per_day', $main_rows[0] ), 'JSON site rows must not duplicate the network error rate.' );
+	health_command_assert_same( false, array_key_exists( 'errors_per_day', $main_rows[0] ), 'JSON site rows must not imply per-site error attribution.' );
 
 	// Bootstrapping the Events site exposes its site-owned queue on the Events row.
 	$health_command_current_blog = 7;
@@ -119,7 +141,7 @@ namespace {
 		'stuck_processing_count' => 626,
 	);
 	$command->health( array(), array( 'format' => 'json' ) );
-	$events_rows = $health_command_formats[1]['items'];
+	$events_rows = WP_CLI::$printed[1]['value']['sites'];
 	health_command_assert_same( HealthCommand::GAP, $events_rows[0]['queue_failed'], 'The main-site row must remain uninstrumented in an Events bootstrap.' );
 	health_command_assert_same( HealthCommand::GAP, $events_rows[0]['queue_stuck'], 'The main-site row must remain uninstrumented in an Events bootstrap.' );
 	health_command_assert_same( 1027, $events_rows[1]['queue_failed'], 'The Events row must expose its failed jobs.' );
@@ -128,15 +150,41 @@ namespace {
 	// A partial or malformed owner payload must remain visibly uninstrumented.
 	$health_command_jobs_ability->result = array( 'failed_count' => 0 );
 	$command->health( array(), array( 'format' => 'json' ) );
-	$malformed_rows = $health_command_formats[2]['items'];
+	$malformed_rows = WP_CLI::$printed[2]['value']['sites'];
 	health_command_assert_same( HealthCommand::GAP, $malformed_rows[1]['queue_failed'], 'A partial payload must not become a healthy failed count.' );
 	health_command_assert_same( HealthCommand::GAP, $malformed_rows[1]['queue_stuck'], 'A partial payload must not become a healthy stuck count.' );
 
 	$health_command_jobs_ability->result = new WP_Error();
 	$command->health( array(), array( 'format' => 'json' ) );
-	$error_rows = $health_command_formats[3]['items'];
+	$error_rows = WP_CLI::$printed[3]['value']['sites'];
 	health_command_assert_same( HealthCommand::GAP, $error_rows[1]['queue_failed'], 'An owner error must not become a healthy failed count.' );
 	health_command_assert_same( HealthCommand::GAP, $error_rows[1]['queue_stuck'], 'An owner error must not become a healthy stuck count.' );
+
+	// CSV must carry the host-wide rate only on an explicitly scoped network row.
+	$health_command_current_blog = 1;
+	$health_command_jobs_ability->result = array(
+		'failed_count'           => 3,
+		'stuck_processing_count' => 1,
+	);
+	$command->health( array(), array( 'format' => 'csv' ) );
+	$csv = $health_command_formats[0];
+	health_command_assert_same( 'csv', $csv['format'], 'CSV must use the requested formatter.' );
+	health_command_assert_same( 3, count( $csv['items'] ), 'CSV must contain one network row and one row per site.' );
+	health_command_assert_same( 'network', $csv['items'][0]['scope'], 'CSV must identify the network row explicitly.' );
+	health_command_assert_same( 42.5, $csv['items'][0]['network_errors_per_day'], 'CSV must report the error rate on the network row.' );
+	health_command_assert_same( '', $csv['items'][0]['site'], 'The network row must not claim a site identity.' );
+	health_command_assert_same( 'site', $csv['items'][1]['scope'], 'CSV must identify site rows explicitly.' );
+	health_command_assert_same( '', $csv['items'][1]['network_errors_per_day'], 'CSV site rows must not duplicate the network error rate.' );
+	health_command_assert_same( 3, $csv['items'][1]['queue_failed'], 'CSV must retain context-valid site queue fields.' );
+	health_command_assert_same( HealthCommand::GAP, $csv['items'][2]['queue_failed'], 'CSV must retain uninstrumented queue fields for other sites.' );
+
+	// Human output continues to label and print the error rate once network-wide.
+	WP_CLI::$messages = array();
+	$command->health( array(), array( 'format' => 'table' ) );
+	$table = implode( "\n", WP_CLI::$messages );
+	health_command_assert_contains( 'Network-wide', $table, 'Table output must retain its network scope label.' );
+	health_command_assert_contains( 'Errors/day:  42.5', $table, 'Table output must retain the network error rate.' );
+	health_command_assert_same( 1, substr_count( $table, 'Errors/day:' ), 'Table output must print the network error rate once.' );
 
 	echo "HealthCommandTest passed\n";
 }


### PR DESCRIPTION
## Summary
- separate the host-wide PHP error rate from per-site health records
- return JSON as a scoped `network`/`sites` envelope and CSV as explicit network/site rows
- preserve the existing network-scoped table presentation and context-valid queue fields

## Problem and source cause
Live `wp extrachill platform health --format=json` repeated the same host-wide `network_errors_per_day` value in every site record. `HealthCommand::health()` computed the analytics-owned `debug.log` rate once before the site loop, then merged that scalar into each machine-readable row, making a network signal look site-attributed.

## Output contracts
- JSON now returns `{ "network": { "errors_per_day": ... }, "sites": [...] }`; site records retain traffic, retention, search gaps, content, and context-valid queue values without an error-rate field.
- CSV now adds a `scope` column, emits one `scope=network` row with `network_errors_per_day`, then emits `scope=site` rows with that cell blank.
- Table output remains unchanged and labels the rate `Network-wide`.

## Compatibility
This intentionally breaks the misleading flat JSON/CSV contract. No concrete consumer requiring the duplicated field was identified, and retaining it would continue to imply unsupported per-site attribution. The new shape uses existing WP-CLI structured JSON and CSV formatters without adding generic infrastructure.

## Tests
- `php tests/HealthCommandTest.php`
- `for test in tests/*Test.php; do php "$test" || exit 1; done`
- `php -l inc/Commands/Platform/HealthCommand.php`
- `php -l tests/HealthCommandTest.php`
- `git diff --check`

Closes #136