### PR TITLE
fix: label raw and trustworthy analytics counts

### DIFF
--- a/inc/Commands/Analytics/ConversionCommand.php
+++ b/inc/Commands/Analytics/ConversionCommand.php
@@ -243,11 +243,17 @@ class ConversionCommand {
 			$outcome       = str_replace( '_', ' ', (string) $type );
 
 			$event_rows[]   = array(
-				'outcome'       => $outcome,
-				'stored'        => $this->count( $type_coverage['stored_events'] ?? 0 ),
-				'auto_excluded' => $this->count( $type_coverage['automatic_registration_excluded'] ?? 0 ),
-				'deduplicated'  => $this->count( $type_coverage['deduplicated_outcomes'] ?? 0 ),
-				'duplicates'    => $this->count( $type_coverage['duplicate_events'] ?? 0 ),
+				'outcome'        => $outcome,
+				'stored'         => $this->count( $type_coverage['stored_events'] ?? 0 ),
+				'bot_excluded'   => $this->count( $type_coverage['confirmed_bot_events_excluded'] ?? 0 ),
+				'auto_excluded'  => $this->count( $type_coverage['automatic_registration_excluded'] ?? 0 ),
+				'trusted'        => $this->count( $type_coverage['trusted_outcomes'] ?? 0 ),
+				'authenticated'  => $this->count( $type_coverage['authenticated_server_outcomes'] ?? 0 ),
+				'visitor'        => $this->count( $type_coverage['visitor_identified_browser_outcomes'] ?? 0 ),
+				'unclassified'   => $this->count( $type_coverage['unclassified_outcomes'] ?? 0 ),
+				'trust_coverage' => (string) ( $type_coverage['trust_coverage_status'] ?? 'unknown' ),
+				'deduplicated'   => $this->count( $type_coverage['deduplicated_outcomes'] ?? 0 ),
+				'duplicates'     => $this->count( $type_coverage['duplicate_events'] ?? 0 ),
 			);
 			$direct_rows[]  = array(
 				'outcome'           => $outcome,
@@ -271,8 +277,8 @@ class ConversionCommand {
 			);
 		}
 
-		WP_CLI::log( 'Outcome event coverage (before attribution):' );
-		Utils\format_items( 'table', $event_rows, array( 'outcome', 'stored', 'auto_excluded', 'deduplicated', 'duplicates' ) );
+		WP_CLI::log( 'Trust-classified outcome coverage (before attribution):' );
+		Utils\format_items( 'table', $event_rows, array( 'outcome', 'stored', 'bot_excluded', 'auto_excluded', 'trusted', 'authenticated', 'visitor', 'unclassified', 'trust_coverage', 'deduplicated', 'duplicates' ) );
 		WP_CLI::log( 'Direct-source lens (source URL resolves to a published entry article):' );
 		Utils\format_items( 'table', $direct_rows, array( 'outcome', 'count', 'coverage', 'with_source', 'attributed', 'missing_source', 'unresolved_source' ) );
 		WP_CLI::log( 'Visitor-journey lens (identified outcome follows a mature entry journey):' );

--- a/inc/Commands/Analytics/SummaryCommand.php
+++ b/inc/Commands/Analytics/SummaryCommand.php
@@ -25,7 +25,7 @@ class SummaryCommand {
 	/**
 	 * Show analytics event summary by type.
 	 *
-	 * Displays event counts grouped by type with daily averages.
+	 * Displays raw, unfiltered event-row counts grouped by type with daily averages.
 	 *
 	 * ## OPTIONS
 	 *
@@ -140,6 +140,7 @@ class SummaryCommand {
 			$period_label = $days > 0 ? "Last {$days} days" : 'All time';
 			$site_label   = $this->format_site_label();
 			WP_CLI::log( sprintf( 'Analytics Summary — %s (%s) — %s', $period_label, $result['period'], $site_label ) );
+			WP_CLI::warning( 'Raw unfiltered event rows: outcome counts are not human conversion KPIs. Use `wp extrachill analytics conversion` for trust-classified outcomes.' );
 			// Surface the exact UTC window the counts were computed over. The window is
 			// rolling (computed at query time), so reporting only the day granularity
 			// hides why a re-run minutes later returns a slightly different count. With

--- a/tests/ConversionCommandTest.php
+++ b/tests/ConversionCommandTest.php
@@ -85,9 +85,15 @@ namespace {
 			'coverage'              => array(
 				'newsletter_signup' => array(
 					'stored_events'                     => 20,
+					'confirmed_bot_events_excluded'     => 1,
 					'automatic_registration_excluded'   => 1,
 					'deduplicated_outcomes'             => 18,
 					'duplicate_events'                  => 1,
+					'trusted_outcomes'                  => 17,
+					'authenticated_server_outcomes'     => 5,
+					'visitor_identified_browser_outcomes' => 12,
+					'unclassified_outcomes'             => 1,
+					'trust_coverage_status'             => 'partial',
 					'with_source_url'                   => 15,
 					'direct_source_attributed'          => 12,
 					'missing_source_url'                => 3,
@@ -100,9 +106,15 @@ namespace {
 				),
 				'user_registration' => array(
 					'stored_events'                     => 5,
+					'confirmed_bot_events_excluded'     => 0,
 					'automatic_registration_excluded'   => 0,
 					'deduplicated_outcomes'             => 5,
 					'duplicate_events'                  => 0,
+					'trusted_outcomes'                  => 5,
+					'authenticated_server_outcomes'     => 5,
+					'visitor_identified_browser_outcomes' => 0,
+					'unclassified_outcomes'             => 0,
+					'trust_coverage_status'             => 'measured',
 					'with_source_url'                   => 0,
 					'direct_source_attributed'          => 0,
 					'missing_source_url'                => 5,
@@ -195,8 +207,10 @@ namespace {
 	conversion_command_test_assert_same( 7, $conversion_command_test_ability->inputs[1]['return_observation_days'], 'Default return observation days must match the ability default.' );
 
 	$event_coverage = $conversion_command_test_formats[1];
-	conversion_command_test_assert_same( array( 'outcome', 'stored', 'auto_excluded', 'deduplicated', 'duplicates' ), $event_coverage['fields'], 'Human output must expose outcome event coverage.' );
+	conversion_command_test_assert_same( array( 'outcome', 'stored', 'bot_excluded', 'auto_excluded', 'trusted', 'authenticated', 'visitor', 'unclassified', 'trust_coverage', 'deduplicated', 'duplicates' ), $event_coverage['fields'], 'Human output must expose owner-classified outcome trust coverage.' );
 	conversion_command_test_assert_same( '20', $event_coverage['items'][0]['stored'], 'Human coverage counts must be formatted for display.' );
+	conversion_command_test_assert_same( '17', $event_coverage['items'][0]['trusted'], 'Human coverage must expose the trustworthy outcome count.' );
+	conversion_command_test_assert_same( 'partial', $event_coverage['items'][0]['trust_coverage'], 'Human coverage must disclose unclassified outcome gaps.' );
 
 	$direct = $conversion_command_test_formats[2];
 	conversion_command_test_assert_same( array( 'outcome', 'count', 'coverage', 'with_source', 'attributed', 'missing_source', 'unresolved_source' ), $direct['fields'], 'Direct-source output must expose source coverage.' );

--- a/tests/SummaryCommandTest.php
+++ b/tests/SummaryCommandTest.php
@@ -145,6 +145,7 @@ namespace {
 	summary_command_test_assert_same( 'table', $table['format'], 'Summary must continue to default to table output.' );
 	summary_command_test_assert_same( array( 'event_type', 'count', 'daily_avg' ), $table['fields'], 'Table columns must remain backward compatible.' );
 	summary_command_test_assert_same( '1,000', $table['items'][0]['count'], 'Table counts must retain human formatting.' );
+	summary_command_test_assert_same( true, false !== strpos( implode( "\n", WP_CLI::$messages ), 'Raw unfiltered event rows' ), 'Human summary output must not present raw outcome rows as conversion KPIs.' );
 
 	fwrite( STDOUT, "SummaryCommand tests passed.\n" );
 }


### PR DESCRIPTION
## Summary
- label `wp extrachill analytics summary` table output as raw, unfiltered event rows rather than human conversion KPIs
- present Analytics-owned trusted, authenticated, visitor-identified, bot-excluded, unclassified, and trust-coverage fields in `wp extrachill analytics conversion`
- preserve complete JSON and CSV pass-through behavior

## Ownership
This remains a thin CLI adapter. All outcome classification and trust semantics live in the coordinated Extra Chill Analytics PR; the CLI only renders the returned contract.

## Verification
- focused SummaryCommand and ConversionCommand tests pass
- Homeboy changed-scope lint: zero findings
- Homeboy changed-scope audit: zero introduced findings
- focused PHPCS and PHP syntax pass

Coordinates with Extra-Chill/extrachill-analytics#254. Merge the Analytics owner change first.